### PR TITLE
[ADD] l10n_ar_sale: Add new field report_price_reduce

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Sale Total Fields',
-    'version': '11.0.1.2.0',
+    'version': '11.0.1.3.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -37,6 +37,17 @@ class SaleOrderLine(models.Model):
         'account.tax',
         compute='_compute_vat_tax_id',
     )
+    report_price_reduce = fields.Monetary(
+        compute='_compute_report_price_reduce'
+    )
+
+    @api.depends('price_unit', 'price_subtotal', 'order_id.vat_discriminated')
+    def _compute_report_price_reduce(self):
+        for line in self:
+            price_type = line.price_subtotal \
+                if line.order_id.vat_discriminated else line.price_total
+            line.report_price_reduce = price_type / line.product_uom_qty \
+                if line.product_uom_qty else 0.0
 
     @api.multi
     @api.depends(


### PR DESCRIPTION
This will be used in website in order to replace the price_reduce_taxexcl and
price_reduce_taxexcl fields that formely were replaced by report_price_unit
and this was giving us troubles in the way that the discount were applied.