### PR TITLE
[PORT] from 11.0

### DIFF
--- a/l10n_ar_stock/models/stock_picking.py
+++ b/l10n_ar_stock/models/stock_picking.py
@@ -141,17 +141,14 @@ class StockPicking(models.Model):
                     'DNI', 'LC', 'LE', 'PAS', 'CI']:
                 dest_tipo_doc = doc_categ_id.code
                 dest_doc = commercial_partner.main_id_number
+                dest_cuit = ''
             else:
                 dest_tipo_doc = ''
                 dest_doc = ''
-
-            dest_tipo_doc = dest_tipo_doc
-            dest_doc = dest_doc
+                dest_cuit = commercial_partner.cuit_required()
 
             dest_cons_final = commercial_partner.\
-                afip_responsability_type_id.id == "5" and '1' or '0'
-
-            dest_cuit = commercial_partner.cuit
+                afip_responsability_type_id.code == "5" and '1' or '0'
 
             REMITOS_PRODUCTOS.append([
                 "02",  # TIPO_REGISTRO


### PR DESCRIPTION
[FIX] l10n_ar_stock: FIx a bug related with COT (#32)

IF the destination of the picking has doc_type difrente than CUIT,  the dest_cuit must be null, otherwise the comparation of the partner afip responsability it's be code not ID.