### PR TITLE
[FIX] l10n_ar_sale: remove transfer_account_id param from _load_template

### DIFF
--- a/l10n_ar_sale/models/account_chart_template.py
+++ b/l10n_ar_sale/models/account_chart_template.py
@@ -10,13 +10,13 @@ class AccountChartTemplate(models.Model):
 
     @api.multi
     def _load_template(
-            self, company, code_digits=None, transfer_account_id=None,
+            self, company, code_digits=None,
             account_ref=None, taxes_ref=None):
         self.ensure_one()
         if company.localization:
             self.generate_sale_checkbook(company)
         return super(AccountChartTemplate, self)._load_template(
-            company, code_digits, transfer_account_id,
+            company, code_digits,
             account_ref, taxes_ref)
 
     @api.model

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -111,7 +111,9 @@ class SaleOrder(models.Model):
             res = {}
             for line in order.order_line:
                 price_reduce = line.price_unit * (1.0 - line.discount / 100.0)
-                taxes = line.report_tax_id.compute_all(price_reduce, quantity=line.product_uom_qty, product=line.product_id, partner=order.partner_shipping_id)['taxes']
+                taxes = line.report_tax_id.compute_all(
+                    price_reduce, quantity=line.product_uom_qty, product=line.product_id,
+                    partner=order.partner_shipping_id)['taxes']
                 for tax in line.report_tax_id:
                     group = tax.tax_group_id
                     res.setdefault(group, {'amount': 0.0, 'base': 0.0})

--- a/l10n_ar_stock/models/account_chart_template.py
+++ b/l10n_ar_stock/models/account_chart_template.py
@@ -10,13 +10,13 @@ class AccountChartTemplate(models.Model):
 
     @api.multi
     def _load_template(
-            self, company, code_digits=None, transfer_account_id=None,
+            self, company, code_digits=None,
             account_ref=None, taxes_ref=None):
         self.ensure_one()
         if company.localization:
             self.generate_stock_book(company)
         return super(AccountChartTemplate, self)._load_template(
-            company, code_digits, transfer_account_id,
+            company, code_digits,
             account_ref, taxes_ref)
 
     @api.model


### PR DESCRIPTION
This method does not have this parameter anymore, it was in version 11.0
but was removed in version 12.0

closes #34 