### PR TITLE
Fills NUMBER with 0 to eight characters

### DIFF
--- a/l10n_ar_stock/models/stock_picking.py
+++ b/l10n_ar_stock/models/stock_picking.py
@@ -145,6 +145,7 @@ class StockPicking(models.Model):
             PREFIJO = str(document_parts['point_of_sale'])
             NUMERO = str(document_parts['invoice_number'])
             PREFIJO = PREFIJO.rjust(5, '0')
+            NUMERO = NUMERO.rjust(8, '0')
 
             # rellenar y truncar a 2
             # TIPO = '{:>2.2}'.format(letter.name)


### PR DESCRIPTION
En la funcion get_arba_file_data de l10n_ar_stock/models/stock_picking.py cuando se obtiene los docuument_parts el invoice_number fue transformado a int y al volver a pasarlo a str no se ajustan la cantidad de 0 a la izquierda. esto hace que se malforme el archivo txt del remito que se pasa a arba para obtener el cot