### PR TITLE
[FIX] l10n_ar: show VAT on invoices report 

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Sale Total Fields',
-    'version': '13.0.1.8.0',
+    'version': '13.0.1.9.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -118,7 +118,7 @@
 
                     <!-- (17) CUIT -->
                     <t t-if="doc.partner_id.vat and doc.partner_id.l10n_latam_identification_type_id.name and doc.partner_id.l10n_latam_identification_type_id.name != 'Sigd'">
-                        <br/><strong><t t-esc="doc.partner_id.l10n_latam_identification_type_id.name or doc.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="doc.partner_id.l10n_ar_formatted_vat if doc.partner_id.l10n_latam_identification_type_id.is_vat else doc.partner_id.vat"/>
+                        <br/><strong><t t-esc="doc.partner_id.l10n_latam_identification_type_id.name or doc.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="doc.partner_id.l10n_ar_formatted_vat or doc.partner_id.vat"/>
                     </t>
 
                 </div>

--- a/l10n_ar_stock/__manifest__.py
+++ b/l10n_ar_stock/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Remitos, COT y demas ajustes de stock para Argentina',
-    'version': '13.0.1.18.0',
+    'version': '13.0.1.19.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_stock/views/report_deliveryslip.xml
+++ b/l10n_ar_stock/views/report_deliveryslip.xml
@@ -84,7 +84,7 @@
 
                     <!-- (17) CUIT -->
                     <t t-if="partner.vat and partner.l10n_latam_identification_type_id.name and partner.l10n_latam_identification_type_id.name != 'Sigd'">
-                        <br/><strong><t t-esc="partner.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="partner.l10n_ar_formatted_vat if partner.l10n_latam_identification_type_id.is_vat else partner.vat"/>
+                        <br/><strong><t t-esc="partner.l10n_latam_identification_type_id.name or o.company_id.country_id.vat_label" id="inv_tax_id_label"/>:</strong> <span t-esc="partner.l10n_ar_formatted_vat or partner.vat"/>
                     </t>
 
                 </div>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Show on the invoices report the identification number of foreign customers when the identification type is "VAT"

Steps to replicate the error:
1. Create a partner with:
    - Responsibility type: "Cliente / Proveedor del Exterior"
    - Identification number: "VAT" with a random number.
2. Create and print an invoice for this partner.

**Current behavior before PR:**
Before this commit, the vat number was empty.

**Desired behavior after PR is merged:**
Show de number
