### PR TITLE
[IMP] l10n_ar_stock_delivery: add carrier identification

### DIFF
--- a/l10n_ar_stock_delivery/__manifest__.py
+++ b/l10n_ar_stock_delivery/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Integracion entre modulo delivery y localización argentina',
-    'version': '13.0.1.4.0',
+    'version': '13.0.1.5.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_stock_delivery/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_delivery/views/report_deliveryslip.xml
@@ -16,6 +16,9 @@
             <t t-if="o.picking_type_id.code == 'outgoing' and o.carrier_id">
                 <br/><strong>Carrier:</strong>
                 <span t-field="o.carrier_id"/>
+                <t t-if="o.carrier_id.partner_id.vat">
+                    (<span t-field="o.carrier_id.partner_id.l10n_latam_identification_type_id"/>: <span t-field="o.carrier_id.partner_id.vat"/>)
+                </t>
                 <span t-field="o.carrier_id.partner_id" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': true, 'no_tag_br': True}"/>
             </t>
         </t>


### PR DESCRIPTION
If the picking has a carrier with partner associated, and that partner
has identification number it will be shown after the carrier name in the
report.
Example: [example.pdf](https://github.com/ingadhoc/argentina-sale/files/6779730/Delivery.Slip.-.AFIP.-.AR._OUT_00006.pdf)
