### PR TITLE
[FIX] l10n_ar_sale: only use ar report on ar companies

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Sale Total Fields',
-    'version': '13.0.1.10.0',
+    'version': '13.0.1.11.0',
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -130,3 +130,18 @@ class SaleOrder(models.Model):
                     fmt(l[1]['amount']), fmt(l[1]['base']),
                     len(res),
                 ) for l in res]
+
+    def _get_name_sale_report(self, report_xml_id):
+        """ Method similar to the '_get_name_invoice_report' of l10n_latam_invoice_document
+        Basically it allows different localizations to define it's own report
+        This method should actually go in a sale_ux module that later can be extended by different localizations
+        Another option would be to use report_substitute module and setup a subsitution with a domain
+        """
+        self.ensure_one()
+        # como estamos en estable, para no afectar comportamiento de todos los que tienen country = False
+        # hacemos que se use reporte AR si country = False
+        # podemos borrar esto en un cambio de version con un mensaje a clientes que al actualizar pueden mantener
+        # comportamiento usando el substitution report
+        if not self.company_id.country_id or self.company_id.country_id.code == 'AR':
+            return 'l10n_ar_sale.report_saleorder_document'
+        return report_xml_id

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -138,10 +138,6 @@ class SaleOrder(models.Model):
         Another option would be to use report_substitute module and setup a subsitution with a domain
         """
         self.ensure_one()
-        # como estamos en estable, para no afectar comportamiento de todos los que tienen country = False
-        # hacemos que se use reporte AR si country = False
-        # podemos borrar esto en un cambio de version con un mensaje a clientes que al actualizar pueden mantener
-        # comportamiento usando el substitution report
-        if not self.company_id.country_id or self.company_id.country_id.code == 'AR':
+        if self.company_id.country_id.code == 'AR':
             return 'l10n_ar_sale.report_saleorder_document'
         return report_xml_id

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- we would do something like this if we want it multilocalization compatible as in l10n_latam_invoice_document -->
-    <!-- <template id="report_saleorder" inherit_id="sale.report_saleorder">
+    <template id="report_saleorder" inherit_id="sale.report_saleorder">
         <t t-call="sale.report_saleorder_document" position="attributes">
-            <attribute name="t-call">#{ o.get_custom_report('sale.report_saleorder_document') }</attribute>
+            <attribute name="t-call">#{ doc._get_name_sale_report('sale.report_saleorder_document') }</attribute>
         </t>
     </template>
 
     <template id="report_saleorder_pro_forma" inherit_id="sale.report_saleorder_pro_forma">
         <t t-call="sale.report_saleorder_document" position="attributes">
-            <attribute name="t-call">#{ o.get_custom_report('sale.report_saleorder_document') }</attribute>
+            <attribute name="t-call">#{ doc._get_name_sale_report('sale.report_saleorder_document') }</attribute>
         </t>
-    </template> -->
+    </template>
 
     <!-- we force priority greater than 16 so that it dont break inheritance of report_saleorder_document_inherit_sale_stock. with this we are loosing the incoterm field added but that sale_stock view -->
-    <template id="report_saleorder_document" priority="20" inherit_id="sale.report_saleorder_document">
+    <template id="report_saleorder_document" priority="20" inherit_id="sale.report_saleorder_document" primary="True">
 
         <!-- custom header and footer -->
         <t t-set="doc" position="after">


### PR DESCRIPTION
We use same approach as in invoices, only argentinean companies use this report.
If user wants to use it for another company, he can add it with report_substitute module