### PR TITLE
[FIX] l10n_ar_sale_order_type: Only change the nuber when the checkbook is changed.

### DIFF
--- a/l10n_ar_sale_order_type/models/sale_order.py
+++ b/l10n_ar_sale_order_type/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrder(models.Model):
             sale_checkbook = self.env['sale.checkbook'].browse(vals['sale_checkbook_id'])
             if sale_checkbook.sequence_id:
                 for record in self:
-                    if (
+                    if record.sale_checkbook_id != sale_checkbook and (
                         record.state in {"draft", "sent"}
                         and record.type_id.sequence_id != sale_checkbook.sequence_id
                     ):


### PR DESCRIPTION

For a few cases when change the type and the checkbook of the type is different than the original in the SO and you want to keep the original, odoo assume
that you change the field, but it's not really changed.