### PR TITLE
[FIX] l10n_ar_stock: Solve issue when generate cot with some stock line cancelled.

### DIFF
--- a/l10n_ar_stock/models/stock_picking.py
+++ b/l10n_ar_stock/models/stock_picking.py
@@ -317,7 +317,7 @@ class StockPicking(models.Model):
                 str(int(round(importe * 100.0)))[-14:],
             ])
 
-            for line in rec.mapped('move_lines'):
+            for line in rec.mapped('move_lines').filtered(lambda x: x.product_uom_qty):
 
                 # buscamos si hay unidad de medida de la cateogria que tenga
                 # codigo de arba y usamos esa, ademas convertimos la cantidad


### PR DESCRIPTION
For the generation of the cot, the quantity zero is forbidden, with this change we ensure that any quantity must be different than zero.