### PR TITLE
[IMP] l10n_ar_sale: change message error

### DIFF
--- a/l10n_ar_sale/i18n/es.po
+++ b/l10n_ar_sale/i18n/es.po
@@ -135,11 +135,9 @@ msgstr "Creado en"
 #: code:addons/l10n_ar_sale/models/sale_order_line.py:0
 #, python-format
 msgid ""
-"Debe haber un y solo un impuestos de IVA por línea. Verificar líneas con "
-"producto \"%s\""
+"Debe haber un único impuesto IVA por línea, agréguelo a \"%s\". En "
+"caso de tenerlo, revise la configuración del impuesto."
 msgstr ""
-"Debe haber un y solo un impuestos de IVA por línea. Verificar líneas con "
-"producto \"%s\""
 
 #. module: l10n_ar_sale
 #: model:ir.model.fields,help:l10n_ar_sale.field_res_company__sale_allow_vat_no_discrimination

--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -121,8 +121,8 @@ class SaleOrderLine(models.Model):
                 lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
             if len(vat_taxes) != 1:
                 raise UserError(_(
-                    'Debe haber un y solo un impuestos de IVA por línea. '
-                    'Verificar líneas con producto "%s"' % (
+                    'Debe haber un único impuesto IVA por línea, agréguelo a "%s". '
+                    'En caso de tenerlo, revise la configuración del impuesto.' % (
                         rec.product_id.name)))
 
     def write(self, vals):


### PR DESCRIPTION
The error message now shows that a VAT tax must be added
to that line and that if it is already added, it may be misconfigured.