### PR TITLE
[IMP] l10n_ar_sale: arreglar presupuesto con iva incluido

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Sale Total Fields',
-    'version': "16.0.1.2.0",
+    'version': "16.0.1.3.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -58,43 +58,28 @@ class SaleOrder(models.Model):
                     sale_checkbook.sequence_id._next() or _('New')
         return super(SaleOrder, self).create(vals)
 
-    # TODO merge this on _compute_tax_totals
-    # def _compute_tax_totals_json(self):
-    #     # usamos mismo approach que teniamos para facturas en v13, es decir, con esto sabemos si se está solicitando el
-    #     # json desde reporte o qweb y en esos casos vemos de incluir impuestos, pero en backend siempre discriminamos
-    #     # eventualmente podemos usar mismo approach de facturas en v15 donde ya no se hace asi, si no que cambiamos
-    #     # el reporte de facturas usando nuevo metodo _l10n_ar_get_invoice_totals_for_report
-    #     report_or_portal_view = 'commit_assetsbundle' in self.env.context or \
-    #         not self.env.context.get('params', {}).get('view_type') == 'form'
-    #     if not report_or_portal_view:
-    #         return super()._compute_tax_totals_json()
-    #     for order in self:
-    #         # Hacemos esto para disponer de fecha del pedido y cia para calcular
-    #         # impuesto con código python (por ej. para ARBA).
-    #         # lo correcto seria que esto este en un modulo que dependa de l10n_ar_account_withholding, pero queremos
-    #         # evitar ese modulo adicional por ahora
-    #         date_order = order.date_order or fields.Date.context_today(order)
-    #         order = order.with_context(invoice_date=date_order)
-    #         if order.vat_discriminated:
-    #             super(SaleOrder, order)._compute_tax_totals_json()
-    #         else:
-    #             def compute_taxes(order_line):
-    #                 price = order_line.price_unit * (1 - (order_line.discount or 0.0) / 100.0)
-    #                 order = order_line.order_id
-    #                 return order_line.report_tax_id._origin.compute_all(price, order.currency_id, order_line.product_uom_qty, product=order_line.product_id, partner=order.partner_shipping_id)
-
-    #             account_move = self.env['account.move']
-    #             for order in self:
-    #                 tax_lines_data = account_move._prepare_tax_lines_data_for_totals_from_object(order.order_line, compute_taxes)
-    #                 tax_totals = account_move._get_tax_totals(order.partner_id, tax_lines_data, order.amount_total, order.amount_untaxed, order.currency_id)
-    #                 order.tax_totals_json = json.dumps(tax_totals)
-
     def _compute_tax_totals(self):
         """ Mandamos en contexto el invoice_date para calculo de impuesto con partner aliquot
-        ver módulo l10n_ar_account_withholding"""
+        ver módulo l10n_ar_account_withholding. Además acá reemplazamos el método _compute_tax_totals del módulo sale original de odoo"""
         for rec in self:
             rec = rec.with_context(invoice_date=rec.date_order)
             super(SaleOrder, rec)._compute_tax_totals()
+        report_or_portal_view = 'commit_assetsbundle' in self.env.context or \
+            not self.env.context.get('params', {}).get('view_type') == 'form'
+        if not report_or_portal_view:
+            return
+
+        for order in self.filtered(lambda x: not x.vat_discriminated):
+            tax_groups = order.order_line.mapped('tax_id.tax_group_id')
+            if not tax_groups:
+                continue
+            to_remove_ids = tax_groups.filtered(lambda x: x.l10n_ar_vat_afip_code).ids
+            tax_group_name = list(order.tax_totals['groups_by_subtotal'].keys())[0]
+            tax_group_vals = order.tax_totals['groups_by_subtotal'].get(tax_group_name)
+            updated_tax_group_vals = list(filter(lambda x: x.get('tax_group_id') not in to_remove_ids, tax_group_vals))
+            new_totals = order.tax_totals
+            new_totals['groups_by_subtotal'].update({tax_group_name: updated_tax_group_vals})
+            order.tax_totals = new_totals
 
     def _get_name_sale_report(self, report_xml_id):
         """ Method similar to the '_get_name_invoice_report' of l10n_latam_invoice_document

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -151,4 +151,12 @@
         </xpath>
 
     </template>
+
+    <template id="document_tax_totals" inherit_id="account.document_tax_totals" primary="True">
+        <xpath expr="//t[@t-foreach]/tr" position="attributes">
+            <!-- Solo mostramos el importe sin impuestos si corresponde discriminar iva -->
+            <attribute name="t-if">doc.vat_discriminated</attribute>
+        </xpath>
+    </template>
+
 </odoo>


### PR DESCRIPTION
Task: 28700
Lo que hace este pr es que la impresión del presupuesto discrimine o no el iva de acuerdo a la condición fiscal del cliente.