### PR TITLE
[ADD] l10n_ar_stock: fix report_deliveryslip view

### DIFF
--- a/l10n_ar_stock/__manifest__.py
+++ b/l10n_ar_stock/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Remitos, COT y demas ajustes de stock para Argentina',
-    'version': "17.0.1.2.0",
+    'version': "17.0.1.3.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_stock/views/report_deliveryslip.xml
+++ b/l10n_ar_stock/views/report_deliveryslip.xml
@@ -106,15 +106,13 @@
     <!-- remove default document title -->
     <h2 position="replace"/>
 
-    <div class="row mt32 mb32" position="after">
-        <div t-if="0" id="l10n_ar_stock_div_hide">
-        </div>
-    </div>
-    <div id="l10n_ar_stock_div_hide" position="inside">
-        <div class="row mt32 mb32" position="move"/>
-    </div>
+    <!-- We want to hide order number and shipping address show at to left side of the report -->
+    <xpath expr="//div[@name='div_origin']/.." position="attributes">
+        <attribute name="id">hide_order_and_shipping_date</attribute>
+        <attribute name="t-if">0</attribute>
+    </xpath>
 
-    <div id="l10n_ar_stock_div_hide" position="before">
+    <div id="hide_order_and_shipping_date" position="after">
         <div id="informations" class="row mt32 mb32">
             <div class="col-6">
                 <t t-set="partner" t-value="o.partner_id or (o.move_ids and o.move_ids[0].partner_id)"/>


### PR DESCRIPTION
Odoo change original qweb view so this module views are now invalid. We need to update the views to make them match to new Odoo changes and also make the changes more sustentable (do not use simple class method to search, instead found the div using xpath and give them a name to easly identify in the future, also add a comment to understand why we are hidding)

Ticket 83875