### PR TITLE
[FIX] l10n_ar_sale: Fix in l10n_ar_sale_templates view preserved odoo  ids

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Sale Total Fields',
-    'version': "17.0.1.3.0",
+    'version': "17.0.1.4.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_sale/views/l10n_ar_sale_templates.xml
+++ b/l10n_ar_sale/views/l10n_ar_sale_templates.xml
@@ -20,15 +20,17 @@
         <!-- use column vat instead of taxes and only if vat discriminated -->
 
         <th t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="replace">
-            <th t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>% VAT</span></th>
+            <th id="taxes_header" t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                <span>% VAT</span>
+            </th>
         </th>
         <!-- use column vat instead of taxes and only list vat taxes-->
         <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="replace">
-            <td t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+            <td  id="taxes" t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                 <span t-out="', '.join(map(lambda x: (x.description or x.name), line.tax_id.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))"/>
             </td>
         </td>
-
+        
         <xpath expr="//span[@id='shipping_address']" position="before">
             <div class="mb-3 col-6" groups="l10n_ar_sale.group_delivery_date_on_report_online">
                 <strong>Delivery Date:</strong> <span t-field="sale_order.commitment_date" t-options="{&quot;widget&quot;: &quot;date&quot;}"/>


### PR DESCRIPTION
Previously, the ID 'taxes_header'  and 'taxes' was lost when replacing in
the sales order view. This commit ensures that the ID 
is preserved 
