### PR TITLE
[FIX] l10n_ar_sale: Fix Sale taxes in preview view

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/views/l10n_ar_sale_templates.xml
+++ b/l10n_ar_sale/views/l10n_ar_sale_templates.xml
@@ -13,7 +13,7 @@
         </xpath>
 
         <xpath expr="//span[contains(@t-out, 'line.tax_id')]" position="attributes">
-            <attribute name="t-out">', '.join(map(lambda x: (x.description or x.name), line.report_tax_id))</attribute>
+            <attribute name="t-out">', '.join(map(lambda x: (x.invoice_label or x.name), line.report_tax_id))</attribute>
         </xpath>
 
 
@@ -25,7 +25,7 @@
         <!-- use column vat instead of taxes and only list vat taxes-->
         <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="replace">
             <td id="taxes" t-if="sale_order.vat_discriminated" t-attf-class="text-right {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                <span t-out="', '.join(map(lambda x: (x.description or x.name), line.tax_id.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))"/>
+                <span t-out="', '.join(map(lambda x: (x.invoice_label or x.name), line.tax_id.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)))"/>
             </td>
         </td>
 


### PR DESCRIPTION
Shoudl use invoice_label instead of description. This is the way Odoo works in another simlar qweb reports like invoices.

Ticket 89268