### PR TITLE
[FIX] l10n_ar_sale: Remove delivery date group and related settings

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "summary": "",
     "depends": [
-        "sale",
+        "sale_ux",  # we make it dependent on sale_ux by setting group_delivery_date. More information in ticket 95265
         "l10n_ar_tax",
     ],
     "external_dependencies": {},

--- a/l10n_ar_sale/security/invoice_sale_security.xml
+++ b/l10n_ar_sale/security/invoice_sale_security.xml
@@ -6,9 +6,4 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
-    <record id="group_delivery_date_on_report_online" model="res.groups">
-        <field name="name">Show Delivery Date in Quotations report and online budget</field>
-        <field name="category_id" ref="base.module_category_hidden"/>
-    </record>
-
 </odoo>

--- a/l10n_ar_sale/views/l10n_ar_sale_templates.xml
+++ b/l10n_ar_sale/views/l10n_ar_sale_templates.xml
@@ -29,12 +29,6 @@
             </td>
         </td>
 
-        <xpath expr="//span[@id='shipping_address']" position="before">
-            <div class="mb-3 col-6" groups="l10n_ar_sale.group_delivery_date_on_report_online">
-                <strong>Delivery Date:</strong> <span t-field="sale_order.commitment_date" t-options="{&quot;widget&quot;: &quot;date&quot;}"/>
-            </div>
-        </xpath>
-
     </template>
 
 </odoo>

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -124,7 +124,7 @@
                         <span t-field="doc.validity_date"/>
                     </t>
 
-                    <t groups="l10n_ar_sale.group_delivery_date_on_report_online">
+                    <t groups="sale_ux.group_delivery_date_on_report_online">
                         <br/><strong>Delivery Date: </strong>
                         <span t-out="doc.commitment_date or doc.date_order" t-options='{"widget": "date"}'/>
                     </t>

--- a/l10n_ar_sale/wizards/res_config_settings.py
+++ b/l10n_ar_sale/wizards/res_config_settings.py
@@ -8,7 +8,3 @@ class ResConfigSettings(models.TransientModel):
         "Unit Price w/ Taxes",
         implied_group="l10n_ar_sale.sale_price_unit_with_tax",
     )
-    group_delivery_date = fields.Boolean(
-        "Show Delivery Date in Quotations report and online budget",
-        implied_group="l10n_ar_sale.group_delivery_date_on_report_online",
-    )

--- a/l10n_ar_sale/wizards/res_config_settings_view.xml
+++ b/l10n_ar_sale/wizards/res_config_settings_view.xml
@@ -11,12 +11,6 @@
                     <field name="group_price_unit_with_tax"/>
                 </setting>
             </xpath>
-
-            <xpath expr="//setting[@id='proforma_configuration']" position="after">
-                <setting id="group_delivery_date" help="Shows the delivery date field in the budget report and in the online budget." title="Shows the delivery date field in the budget report and in the online budget.">
-                    <field name="group_delivery_date"/>
-                </setting>
-            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Se hace dependiente de sale_ux para que corra primero el script de migración (pre-migration) de sale_ux https://github.com/ingadhoc/sale/pull/1282