### PR TITLE
[FIX] l10n_ar_sale: Fix sale order line date.

### DIFF
--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -126,8 +126,10 @@ class SaleOrderLine(models.Model):
         """Agregado de taxes de modulo l10n_ar_tax segun fiscal position"""
         super()._compute_tax_id()
 
-        for rec in self.filtered("order_id.fiscal_position_id.l10n_ar_tax_ids"):
-            date = rec.order_id.date_order
+        for rec in self.with_context(tz="America/Argentina/Buenos_Aires").filtered(
+            "order_id.fiscal_position_id.l10n_ar_tax_ids"
+        ):
+            date = fields.Date.to_date(fields.Datetime.context_timestamp(rec, rec.order_id.date_order))
             rec.tax_id += rec.order_id.fiscal_position_id._l10n_ar_add_taxes(
                 rec.order_partner_id, rec.company_id, date, "perception"
             )


### PR DESCRIPTION
The _l10n_ar_add_taxes method of account.fiscal.position of the l10n_ar_tax module ( https://github.com/ingadhoc/odoo-argentina/blob/18.0/l10n_ar_tax/models/account_fiscal_position.py#L10 ) gets the date of the sale.order as datetime.datetime (from l10n_ar_sale module https://github.com/ingadhoc/argentina-sale/blob/18.0/l10n_ar_sale/models/sale_order_line.py#L130 ) but compares it with the from_date and to_date fields of l10n_ar.partner.tax model which are of type datetime.date then we convert the date of the sale.order.line as datetime.date to make a homogeneous comparison between date fields of the same type (datetime.date). Also we ensure to use the timezone of Argentina to avoid issues with timezones when comparing dates.
Ticket adhoc side: 97262, 97292