### PR TITLE
[IMP] l10n_ar_sale: update perceptions when needed

### DIFF
--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -93,3 +93,11 @@ class SaleOrder(models.Model):
             ]
         )
         return True if module_installed else False
+
+    @api.constrains("date_order")
+    @api.onchange("date_order")
+    def _l10n_ar_onchange_date_order(self):
+        self.filtered(
+            lambda x: x.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
+            and x.state not in ["cancel", "sale"]
+        )._recompute_taxes()


### PR DESCRIPTION
Mejora varios casos de uso, por ejemplo:
1. si tengo una venta de julio pero la duplico en agosto, los impuestos deben re-calcularse
2. si duplico una venta de julio en agosto, los impuestos deben re-calcularse

Casos similares ocurren también con clientes que migran y duplican ventas viejas (el impuesto legacy archivado debe re-computarse)