### PR TITLE
[IMP] l10n_ar_sale: price unit precision digits on sale report.

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "18.0.1.4.0",
+    "version": "18.0.1.5.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -15,7 +15,7 @@ class SaleOrderLine(models.Model):
 
     report_price_unit = fields.Float(
         compute="_compute_report_prices_and_taxes",
-        digits="Report Product Price",
+        digits="Product Price",
     )
     price_unit_with_tax = fields.Float(
         compute="_compute_report_prices_and_taxes",
@@ -58,20 +58,28 @@ class SaleOrderLine(models.Model):
         for line in self:
             order = line.order_id
             taxes_included = not order.vat_discriminated
-            price_unit = line.tax_id.with_context(round=False).compute_all(
-                line.price_unit, order.currency_id, 1.0, line.product_id, order.partner_shipping_id
+            price_digits = 10 ** self.env["decimal.precision"].precision_get("Product Price")
+            price_unit = line.tax_id.compute_all(
+                line.price_unit * price_digits, order.currency_id, 1.0, line.product_id, order.partner_shipping_id
             )
             if not taxes_included:
-                report_price_unit = price_unit["total_excluded"]
+                report_price_unit = price_unit["total_excluded"] / price_digits
                 report_price_subtotal = line.price_subtotal
                 not_included_taxes = line.tax_id
                 report_price_net = report_price_unit * (1 - (line.discount or 0.0) / 100.0)
             else:
                 included_taxes = line.tax_id.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
                 not_included_taxes = line.tax_id - included_taxes
-                report_price_unit = included_taxes.with_context(round=False).compute_all(
-                    line.price_unit, order.currency_id, 1.0, line.product_id, order.partner_shipping_id
-                )["total_included"]
+                report_price_unit = (
+                    included_taxes.compute_all(
+                        line.price_unit * price_digits,
+                        order.currency_id,
+                        1.0,
+                        line.product_id,
+                        order.partner_shipping_id,
+                    )["total_included"]
+                    / price_digits
+                )
                 report_price_net = report_price_unit * (1 - (line.discount or 0.0) / 100.0)
                 price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
                 report_price_subtotal = included_taxes.compute_all(

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -53,7 +53,9 @@
         <t t-set="layout_document_title" position="replace"/>
 
         <xpath expr="//span[@t-field='line.price_unit']" position="attributes">
-            <attribute name="t-field">line.report_price_unit</attribute>
+            <attribute name="t-field"></attribute>
+            <attribute name="t-out">line.report_price_unit</attribute>
+            <attribute name="t-options">{"widget": "float", "display_currency": doc.currency_id, "decimal_precision": "Product Price"}</attribute>
         </xpath>
 
         <t t-set="taxes" position="attributes">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
If "Product Price" Decimal Accuracy has more than 2 digits, then the unit price on the printed report has only 2 digits when Argentinean sale report is printed and this causes that quantity * price on each invoice line does not result the amount shown on the "Amount" column. This issue was fixed for invoices but not for sale orders: https://github.com/odoo/odoo/pull/171131 .

**Steps to reproduce**:
1. Log ing with admin user on adhoc runbot 18 instance, activate developer mode and install l10n_ar_sale module.
2. Take position on "Muebleria ARG" company, go to menu "Setting / Technical / Database Structure / Decimal Accuracy" and set 4 digits for "Product Price".
<img width="198" height="155" alt="image" src="https://github.com/user-attachments/assets/88ebf093-0de8-4841-9631-53e81c8cf29d" />

3. Create a sale order to the partner "Consumidor Final Anónimo" (if the partner is "Consumidor Final Anónimo" then taxes are not discriminated on the printed sale report --> document type = "FACTURAS B"). The sale order must have an invoice line with product price with 4 digits, for example: quantity 3000, price 65.3057 and tax "IVA 21%".
<img width="1200" height="988" alt="image" src="https://github.com/user-attachments/assets/d007f1a6-72cf-4818-bf89-e36d762f40f7" />

5. Confirm and print the sale order. The result of quantity * price is not the amount shown on the printed invoice (3000 * 79.02 != 237059.69)
<img width="770" height="347" alt="image" src="https://github.com/user-attachments/assets/56d6cd83-f6cb-4ff7-8e7c-2676dc088629" />


**Current behavior before PR**:
If "Product Price" Decimal Accuracy has more than 2 digits, then the unit price on the printed report has only 2 digits when Argentinean sale report is printed and this causes that quantity * price on each invoice line does not result the amount shown on the amount column.

**Desired behavior after PR is merged**:
If "Product Price" Decimal Accuracy has more than 2 digits, then the unit price on the printed report has the same quantity of digits set on "Product Price" Decimal Accuracy when Argentinean sale report is printed.

_Task Adhoc side_: 55629