### PR TITLE
[FIX] l10n_ar_sale: Fix column tag in sale report templates

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "18.0.1.5.0",
+    "version": "18.0.1.6.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -84,12 +84,12 @@
 
         <!-- We change the name of the column depending on the tax discrimination -->
         <th name="th_subtotal" class="text-end" position="replace">
-            <td t-if="doc.vat_discriminated" class="text-end" >
+            <th t-if="doc.vat_discriminated" class="text-end" >
                 <span>SubTotal</span>
-            </td>
-            <td t-else="" class="text-end">
+            </th>
+            <th t-else="" class="text-end">
                 <span>Total</span>
-            </td>
+            </th>
         </th>
 
         <div id="informations" position="replace">


### PR DESCRIPTION
This PR is to fix the alignment of the "Total" and "Subtotal" tags on sales reports
Before the PR:
<img width="803" height="440" alt="image" src="https://github.com/user-attachments/assets/2678d685-906f-4a9e-89b5-caf4e3529d99" />

After:
<img width="785" height="357" alt="image" src="https://github.com/user-attachments/assets/bfdcd7ab-13ce-42eb-b3cd-b91ce637fe5e" />

