### PR TITLE
[FIX] l10n_ar_sale: Ensure VAT tax validation includes goods and services

### DIFF
--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -111,6 +111,7 @@ class SaleOrderLine(models.Model):
             lambda x: not x.display_type
             and x.company_id.country_id == self.env.ref("base.ar")
             and x.company_id.l10n_ar_company_requires_vat
+            and x.product_type in ["consu", "service"]
         ):
             vat_taxes = rec.tax_id.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
             if len(vat_taxes) != 1:


### PR DESCRIPTION
This PR is to avoid checking lines when product type is "Combo", since it will always have tax_id = False: https://github.com/adhoc-cicd/odoo-odoo/blob/af8fcbfed620ff900d81f03c413a59bb9e6f40b7/addons/sale/models/sale_order_line.py#L520