### PR TITLE
[FIX] l10n_ar_sale: prioritize views to avoid xpath issues

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/views/l10n_ar_sale_templates.xml
+++ b/l10n_ar_sale/views/l10n_ar_sale_templates.xml
@@ -1,5 +1,5 @@
 <odoo>
-    <template id="sale_order_portal_content" inherit_id="sale.sale_order_portal_content" name="Sales Order">
+    <template id="sale_order_portal_content" priority="20" inherit_id="sale.sale_order_portal_content" name="Sales Order">
 
         <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
             <attribute name="t-field">line.report_price_unit</attribute>

--- a/l10n_ar_sale/views/sale_report_templates.xml
+++ b/l10n_ar_sale/views/sale_report_templates.xml
@@ -155,7 +155,7 @@
         </t>
 
     </template>
-    <template id="sale_order_portal_content_discount" inherit_id="sale.sale_order_portal_content">
+    <template id="sale_order_portal_content_discount" priority="20" inherit_id="sale.sale_order_portal_content">
 
         <xpath expr="//t[@t-out='(1-line.discount / 100.0) * line.price_unit']" position="attributes">
             <attribute name="t-out">(1-line.discount / 100.0) * line.report_price_unit</attribute>


### PR DESCRIPTION
Cambiamos la prioridad de las vistas de l10n_ar_sale para que tengan siempre secuencias posteriores a las de sale_subscription. Esto es porque en l10n_ar_sale modificamos el campo `line.price_unit` y si las vistas de sale_subscription quedan con secuencia posterior, se rompen por no encontrarlo. 

