### PR TITLE
[FIX] l10n_ar_sale: duplicado de órdenes de venta, cómputo de impuestos

### DIFF
--- a/l10n_ar_sale/__manifest__.py
+++ b/l10n_ar_sale/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Sale Total Fields",
-    "version": "18.0.1.7.0",
+    "version": "18.0.1.8.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -94,7 +94,7 @@ class SaleOrder(models.Model):
         )
         return True if module_installed else False
 
-    @api.onchange("date_order")
+    @api.onchange("partner_id", "date_order")
     def _l10n_ar_recompute_fiscal_position_taxes(self):
         """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
         impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
@@ -112,9 +112,7 @@ class SaleOrder(models.Model):
             for line in rec.order_line:
                 to_unlink = line.tax_id.filtered(lambda x: x.tax_group_id in fp_tax_groups)
                 if to_unlink._origin != new_taxes:
-                    line.tax_id = [(3, tax.id) for tax in to_unlink] + [
-                        (4, tax.id) for tax in new_taxes if tax not in line.tax_id
-                    ]
+                    line.tax_id = [(3, tax.id) for tax in to_unlink] + [(4, tax.id) for tax in new_taxes]
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una venta porque puede ser que la orden venga de otro periodo

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -15,8 +15,6 @@ class SaleOrder(models.Model):
     vat_discriminated = fields.Boolean(
         compute="_compute_vat_discriminated",
     )
-    # Hacemos almacenado show_update_fpos para que funcione el _onchange_fpos_id_show_update_fpos
-    show_update_fpos = fields.Boolean(store=True)
 
     @api.depends(
         "partner_id.l10n_ar_afip_responsibility_type_id",
@@ -96,11 +94,14 @@ class SaleOrder(models.Model):
         )
         return True if module_installed else False
 
-    @api.onchange("date_order")
+    @api.onchange("date_order", "commercial_partner_id")
     def _l10n_ar_recompute_fiscal_position_taxes(self):
-        """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
-        impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
-        reemplazamos por los nuevos impuestos.
+        """Recalculamos las percepciones si cambiamos la fecha de la orden de venta o el commercial partner.
+                Para ello nos basamos en los impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
+                reemplazamos por los nuevos impuestos.
+                NO lo hacemos para el cambio de fiscal_position_id porque el onchange de fiscal_position_id implementado en sale_ux ya recomputa todos los taxes
+                NOTA: en facturas no tenemos approach exactamente igual ya que en facturas es opcional el auto update a través del módulo
+        account_invoice_fiscal_position_update
         """
         for rec in self.filtered(
             lambda x: (
@@ -125,16 +126,3 @@ class SaleOrder(models.Model):
         recs = super().copy(default=default)
         recs._l10n_ar_recompute_fiscal_position_taxes()
         return recs
-
-    @api.onchange("commercial_partner_id")
-    def _onchange_fpos_id_show_update_fpos(self):
-        """Si cambiamos el partner y la posicion fiscal es la misma (super no configuró show_update_fpos = True) y tiene impuestos de tipo percepcion, mostramos el boton de actualizar posicion fiscal
-        ya que las alícuotas pueden ser diferentes"""
-        super()._onchange_fpos_id_show_update_fpos()
-        if (
-            not self.show_update_fpos
-            and self.order_line
-            and self.commercial_partner_id != self._origin.commercial_partner_id
-            and self.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
-        ):
-            self.show_update_fpos = True

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -94,7 +94,7 @@ class SaleOrder(models.Model):
         )
         return True if module_installed else False
 
-    @api.onchange("partner_id", "date_order")
+    @api.onchange("date_order")
     def _l10n_ar_recompute_fiscal_position_taxes(self):
         """Recalculamos las percepciones si cambiamos la fecha de la orden de venta. Para ello nos basamos en los
         impuestos de la posicion fiscal, buscamos si hay impuestos existentes para los tax groups involucrados y los
@@ -121,3 +121,16 @@ class SaleOrder(models.Model):
         recs = super().copy(default=default)
         recs._l10n_ar_recompute_fiscal_position_taxes()
         return recs
+
+    @api.onchange("commercial_partner_id", "fiscal_position_id")
+    def _onchange_fpos_id_show_update_fpos(self):
+        """Si cambiamos el partner y la posicion fiscal es la misma (super no configuró show_update_fpos = True) y tiene impuestos de tipo percepcion, mostramos el boton de actualizar posicion fiscal
+        ya que las alícuotas pueden ser diferentes"""
+        super()._onchange_fpos_id_show_update_fpos()
+        if (
+            not self.show_update_fpos
+            and self.order_line
+            and self.commercial_partner_id != self._origin.commercial_partner_id
+            and self.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
+        ):
+            self.show_update_fpos = True

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -112,7 +112,7 @@ class SaleOrder(models.Model):
             for line in rec.order_line:
                 to_unlink = line.tax_id.filtered(lambda x: x.tax_group_id in fp_tax_groups)
                 if to_unlink._origin != new_taxes:
-                    line.tax_id = [(3, tax.id) for tax in to_unlink] + [(4, tax.id) for tax in new_taxes]
+                    line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una venta porque puede ser que la orden venga de otro periodo

--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -15,6 +15,8 @@ class SaleOrder(models.Model):
     vat_discriminated = fields.Boolean(
         compute="_compute_vat_discriminated",
     )
+    # Hacemos almacenado show_update_fpos para que funcione el _onchange_fpos_id_show_update_fpos
+    show_update_fpos = fields.Boolean(store=True)
 
     @api.depends(
         "partner_id.l10n_ar_afip_responsibility_type_id",
@@ -101,8 +103,10 @@ class SaleOrder(models.Model):
         reemplazamos por los nuevos impuestos.
         """
         for rec in self.filtered(
-            lambda x: x.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
-            and x.state not in ["cancel", "sale"]
+            lambda x: (
+                x.fiscal_position_id.l10n_ar_tax_ids.filtered(lambda x: x.tax_type == "perception")
+                and x.state not in ["cancel", "sale"]
+            )
         ):
             fp_tax_groups = rec.fiscal_position_id.l10n_ar_tax_ids.filtered(
                 lambda x: x.tax_type == "perception"
@@ -112,7 +116,7 @@ class SaleOrder(models.Model):
             for line in rec.order_line:
                 to_unlink = line.tax_id.filtered(lambda x: x.tax_group_id in fp_tax_groups)
                 if to_unlink._origin != new_taxes:
-                    line.tax_ids = (line.tax_ids - to_unlink) | new_taxes
+                    line.tax_id = (line.tax_id - to_unlink) | new_taxes
 
     def copy(self, default=None):
         """Re computamos las percepciones al duplicar una venta porque puede ser que la orden venga de otro periodo
@@ -122,7 +126,7 @@ class SaleOrder(models.Model):
         recs._l10n_ar_recompute_fiscal_position_taxes()
         return recs
 
-    @api.onchange("commercial_partner_id", "fiscal_position_id")
+    @api.onchange("commercial_partner_id")
     def _onchange_fpos_id_show_update_fpos(self):
         """Si cambiamos el partner y la posicion fiscal es la misma (super no configuró show_update_fpos = True) y tiene impuestos de tipo percepcion, mostramos el boton de actualizar posicion fiscal
         ya que las alícuotas pueden ser diferentes"""


### PR DESCRIPTION
Si tengo una Orden de venta con impuesto de iva y percepción de CABA validada, si luego al contacto le agrego impuesto de ARBA, al duplicar la OV se crea solamente con el impuesto de arba y luego al validar se borra el impuesto de arba y se pone el de caba. VIDEO REPLICA RUNBOT ADHOC --> https://drive.google.com/file/d/1RGyX5SuHCgBjABleQQovwuAfm3uaUlK_/view (importante: el video muestra la réplica con facturas pero con órdenes de venta sucede lo mismo).

Este pull request va junto a https://github.com/ingadhoc/odoo-argentina/pull/1295
También necesitamos que se recompute los impuestos al cambiar el contacto --> ver video jgo https://drive.google.com/file/d/1C7oS4EjxmMYzM2N-1MibwbshuShGbSr-/view reportado en ticket 110059 (ver nota jgo 05/02/2026 23:32pm https://www.adhoc.inc/mail/message/15914070 ). Al cambiar un partner, si la FP cambia odoo ofrece un botón para re-calcular. Pero en el caso de que el nuevo partner tenga misma FP, no se recalculan los impuestos. Esto es un problema porque en Argentina, aunque la FP sea la misma, los impuestos pueden variar dependiendo del partner (por ejemplo, por ser monotributista o no). Con este cambio, al cambiar el partner, se recalcularán los impuestos aunque la FP sea la misma.

Ticket Adhoc: 110078