### PR TITLE
[FIX] l10n_ar_sale: add perceptions to delivery lines

### DIFF
--- a/l10n_ar_sale/models/sale_order_line.py
+++ b/l10n_ar_sale/models/sale_order_line.py
@@ -94,6 +94,30 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals):
+        # Para líneas de delivery, _compute_tax_ids es ignorado porque _prepare_delivery_line_vals
+        # setea tax_ids explícitamente con fiscal_position.map_tax(), que no llama a
+        # _l10n_ar_add_taxes() y omite las percepciones. Al pasar tax_ids explícito en el
+        # create(), el ORM usa ese valor y descarta el resultado del compute. Corregimos esto
+        # enriqueciendo los vals antes del super() para que las percepciones queden incluidas.
+        if "is_delivery" in self._fields:
+            for v in vals:
+                if not v.get("is_delivery"):
+                    continue
+                order = self.env["sale.order"].browse(v.get("order_id"))
+                if not order.fiscal_position_id.l10n_ar_tax_ids:
+                    continue
+                date = fields.Date.to_date(
+                    fields.Datetime.context_timestamp(
+                        order.with_context(tz="America/Argentina/Buenos_Aires"),
+                        order.date_order,
+                    )
+                )
+                perception_taxes = order.fiscal_position_id._l10n_ar_add_taxes(
+                    order.partner_id, order.company_id, date, "perception"
+                )
+                if perception_taxes:
+                    existing_ids = {id_ for cmd in v.get("tax_ids", []) if cmd[0] == 6 for id_ in cmd[2]}
+                    v["tax_ids"] = [(6, 0, list(existing_ids | set(perception_taxes.ids)))]
         rec = super(SaleOrderLine, self).create(vals)
         rec.check_vat_tax()
         return rec


### PR DESCRIPTION
When adding a shipping cost (delivery) to a sale order with a fiscal position that includes perceptions (e.g. Percepciones CABA), the delivery line was missing the perception tax.

Root cause: `_prepare_delivery_line_vals` (native delivery module) explicitly sets `tax_ids` in the create vals using `fiscal_position. map_tax()`, which only applies standard tax substitution but never calls `_l10n_ar_add_taxes()`. When `tax_ids` is provided explicitly in create(), the ORM uses it as-is and skips `_compute_tax_ids` (which is the method that adds perceptions in l10n_ar_sale).

Fix: override `create()` in SaleOrderLine to enrich the vals for delivery lines with the perceptions from `_l10n_ar_add_taxes()` before calling super(). The `'is_delivery' in self._fields` guard makes the code a no-op when the delivery module is not installed.