### PR TITLE
[FIX] l10n_ar_sale: set expo journal when invoicing from sale order

### DIFF
--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -58,6 +58,40 @@ class SaleOrder(models.Model):
             return "l10n_ar_sale.report_saleorder_document"
         return report_xml_id
 
+    def _prepare_invoice(self):
+        res = super()._prepare_invoice()
+        return self._l10n_ar_set_expo_journal(res)
+
+    def _l10n_ar_set_expo_journal(self, invoice_vals):
+        """Switch to an export journal when the partner requires export document types.
+
+        Mirrors _onchange_partner_journal (l10n_ar) which only fires in the UI;
+        called from _prepare_invoice so it also applies when invoicing from a sale order.
+        """
+        if self.company_id.account_fiscal_country_id.code != "AR":
+            return invoice_vals
+        partner = self.partner_invoice_id.commercial_partner_id
+        res_code = partner.l10n_ar_afip_responsibility_type_id.code
+        expo_systems = ["FEERCEL", "FEEWS", "FEERCELP"]
+        if res_code not in ["8", "9", "10"]:
+            return invoice_vals
+        current_journal = (
+            self.env["account.journal"].browse(invoice_vals["journal_id"]) if invoice_vals.get("journal_id") else None
+        )
+        if not current_journal or current_journal.l10n_ar_afip_pos_system not in expo_systems:
+            expo_journal = self.env["account.journal"].search(
+                [
+                    *self.env["account.journal"]._check_company_domain(self.company_id),
+                    ("l10n_latam_use_documents", "=", True),
+                    ("type", "=", "sale"),
+                    ("l10n_ar_afip_pos_system", "in", expo_systems),
+                ],
+                limit=1,
+            )
+            if expo_journal:
+                invoice_vals["journal_id"] = expo_journal.id
+        return invoice_vals
+
     def _create_invoices(self, grouped=False, final=False, date=None):
         """Por alguna razon cuando voy a crear la factura a traves de una devolucion, no me esta permitiendo crearla
         y validarla porque resulta el campo tipo de documento esta quedando vacio. Este campo se llena y computa

--- a/l10n_ar_sale_order_type/models/sale_order.py
+++ b/l10n_ar_sale_order_type/models/sale_order.py
@@ -8,6 +8,11 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    def _l10n_ar_set_expo_journal(self, invoice_vals):
+        if self.type_id.journal_id:
+            return invoice_vals
+        return super()._l10n_ar_set_expo_journal(invoice_vals)
+
     @api.depends("type_id.discriminate_taxes")
     def _compute_vat_discriminated(self):
         recs = self.filtered(lambda x: x.type_id.discriminate_taxes in ["yes", "no"])


### PR DESCRIPTION
## Summary

When creating an invoice from a sale order for a partner with an AFIP responsibility that requires export documents (codes `'8'`, `'9'`, `'10'`), the default domestic journal (RAW_MAW/RLI_RLM) does not include export document type codes (`19`, `20`, `21`). As a result, Factura E (code 19) is never available or auto-selected.

The existing `_onchange_partner_journal` in `l10n_ar` switches to an export journal automatically in the UI, but it does not run when invoices are generated programmatically via `_create_invoices`.

## Changes

- `l10n_ar_sale/models/sale_order.py`: overrides `_prepare_invoice` to call `_l10n_ar_set_expo_journal`, which mirrors `_onchange_partner_journal` logic — detects partners requiring export documents and switches `journal_id` to the first available FEERCEL/FEEWS/FEERCELP journal before the invoice record is created.
- Only applies when `account_fiscal_country_id.code == 'AR'` and the current journal is not already an export POS system. Early-returns for non-export responsibility codes.

## Test plan

- [ ] Partner with AFIP responsibility IVA Liberado (code `10`): create sale order → `Create Invoice` — confirm Factura E (document type 19) is auto-selected.
- [ ] Partner with domestic responsibility (RI code `1`, CF code `5`): invoice creation proceeds normally with domestic journal.
- [ ] When no export journal exists in the company: invoice creation proceeds without error, domestic journal kept.
- [ ] Sale order with `sale_order_type` that has an explicit export journal configured: existing expo journal is detected, no override occurs.