### PR TITLE
[ADD] l10n_ar_stock_preprinted: remito preimpreso (tarea 71244)

### DIFF
--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -10,9 +10,9 @@
    :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 
-===============================
+==================================
 Remito Preimpreso para Argentina
-===============================
+==================================
 
 Reincorpora el soporte de **remitos preimpresos de imprenta** sobre el flujo de
 remitos argentinos de ``l10n_ar_stock`` / ``l10n_ar_stock_ux``.

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -19,37 +19,32 @@ remitos argentinos de ``l10n_ar_stock`` / ``l10n_ar_stock_ux``.
 
 Un remito preimpreso es papel provisto por una imprenta que ya trae impresos el
 encabezado, la numeración y el CAI. En ese caso Odoo solo imprime el contenido
-variable (productos, cliente) y numera las transferencias según los comprobantes
-(hojas) que consume.
+variable (productos, cliente) y numera la entrega según las hojas que realmente
+se imprimen.
 
 Cómo se distingue del autoimpreso
 =================================
 
-Un casillero **Autoimpreso** en el tipo de operación define el modo:
+El modo se **autocalcula según el CAI** del tipo de operación:
 
-* **Autoimpreso** (tildado) — Odoo imprime el comprobante completo (encabezado,
-  número y CAI); el CAI es obligatorio. Se numera con un único número por
-  transferencia (comportamiento estándar de ``l10n_ar_stock``).
-* **Preimpreso** (destildado) — el papel de imprenta ya trae encabezado,
-  numeración y CAI. No se pide CAI y Odoo solo imprime el contenido variable,
-  numerando según las hojas consumidas.
+* **Autoimpreso** — el tipo de operación tiene CAI cargado. Odoo imprime el
+  comprobante completo (encabezado, número y CAI) y numera con un único número
+  por transferencia (comportamiento estándar de ``l10n_ar_stock``).
+* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
+  pero **no** tiene CAI. Este módulo habilita ese caso relajando la
+  obligatoriedad del CAI.
 
 Qué agrega
 ==========
 
-* ``stock.picking.type.l10n_ar_autoprinted``: casillero *Autoimpreso* (por
-  defecto verdadero). Al destildarlo, el CAI deja de pedirse y aparecen los
-  *Renglones por Remito*.
+* ``stock.picking.type.l10n_ar_autoprinted`` (computado): casillero *Autoimpreso*
+  de solo lectura; verdadero cuando hay CAI cargado.
 * ``stock.picking.type.l10n_ar_is_preprinted`` (computado): verdadero cuando hay
-  documento de remito y el tipo **no** es autoimpreso. Lo usan el reporte y la
-  numeración.
-* ``stock.picking.type.l10n_ar_lines_per_voucher``: renglones que entran en cada
-  hoja preimpresa. Se usa para calcular cuántos números consume una entrega
-  larga. Si es 0, cada entrega consume un único número.
-* Numeración: al generar la guía de remito en un tipo preimpreso, se asignan
-  tantos números consecutivos como hojas consuma la entrega
-  (``ceil(renglones / renglones_por_hoja)``), separados por coma, sin datos de
-  CAI.
+  documento de remito y no hay CAI. Lo usan el reporte y la numeración.
+* Numeración: al generar la guía de remito en un tipo preimpreso, se renderiza el
+  comprobante de entrega, se cuentan las **hojas (páginas) que se imprimen** y se
+  asignan tantos números consecutivos como hojas, separados por coma y sin datos
+  de CAI.
 * Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
   CAI (ya vienen en el papel).
 
@@ -60,8 +55,8 @@ En *Inventario > Configuración > Tipos de operación*, para un tipo de operaci�
 de salida:
 
 #. Definir el *Tipo de documento* de remito.
-#. Destildar *Autoimpreso* (así el tipo pasa a preimpreso).
-#. Opcionalmente cargar *Renglones por Remito*.
+#. Dejar el *CAI* vacío (así el casillero *Autoimpreso* queda destildado y el
+   tipo pasa a preimpreso).
 
 Credits
 =======

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -1,0 +1,66 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================
+Remito Preimpreso para Argentina
+===============================
+
+Reincorpora el soporte de **remitos preimpresos de imprenta** sobre el flujo de
+remitos argentinos de ``l10n_ar_stock`` / ``l10n_ar_stock_ux``.
+
+Un remito preimpreso es papel provisto por una imprenta que ya trae impresos el
+encabezado, la numeración y el CAI. En ese caso Odoo solo imprime el contenido
+variable (productos, cliente) y numera las transferencias según los comprobantes
+(hojas) que consume.
+
+Cómo se distingue del autoimpreso
+=================================
+
+El modo se **deriva del tipo de operación**, sin campos nuevos que el usuario
+deba marcar:
+
+* **Autoimpreso** — el tipo de operación tiene CAI cargado. Se imprime el
+  comprobante completo (encabezado, número y CAI) y se numera con un único
+  número por transferencia (comportamiento estándar de ``l10n_ar_stock``).
+* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
+  configurado pero **no** tiene CAI (el CAI viene impreso en el papel). Este
+  módulo habilita ese caso relajando la obligatoriedad del CAI.
+
+Qué agrega
+==========
+
+* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): indica si el tipo de
+  operación es preimpreso (tiene documento de remito y no tiene CAI).
+* ``stock.picking.type.l10n_ar_lines_per_voucher``: renglones que entran en cada
+  hoja preimpresa. Se usa para calcular cuántos números consume una entrega
+  larga. Si es 0, cada entrega consume un único número.
+* Numeración: al generar la guía de remito en un tipo preimpreso, se asignan
+  tantos números consecutivos como hojas consuma la entrega
+  (``ceil(renglones / renglones_por_hoja)``), separados por coma, sin datos de
+  CAI.
+* Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
+  CAI (ya vienen en el papel).
+
+Configuración
+=============
+
+En *Inventario > Configuración > Tipos de operación*, para un tipo de operación
+de salida:
+
+#. Definir el *Tipo de documento* de remito.
+#. Dejar el *CAI* vacío (así el tipo pasa a preimpreso).
+#. Opcionalmente cargar *Renglones por Remito*.
+
+Credits
+=======
+
+|company| |company_logo|

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -25,21 +25,24 @@ variable (productos, cliente) y numera las transferencias según los comprobante
 Cómo se distingue del autoimpreso
 =================================
 
-El modo se **deriva del tipo de operación**, sin campos nuevos que el usuario
-deba marcar:
+Un casillero **Autoimpreso** en el tipo de operación define el modo:
 
-* **Autoimpreso** — el tipo de operación tiene CAI cargado. Se imprime el
-  comprobante completo (encabezado, número y CAI) y se numera con un único
-  número por transferencia (comportamiento estándar de ``l10n_ar_stock``).
-* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
-  configurado pero **no** tiene CAI (el CAI viene impreso en el papel). Este
-  módulo habilita ese caso relajando la obligatoriedad del CAI.
+* **Autoimpreso** (tildado) — Odoo imprime el comprobante completo (encabezado,
+  número y CAI); el CAI es obligatorio. Se numera con un único número por
+  transferencia (comportamiento estándar de ``l10n_ar_stock``).
+* **Preimpreso** (destildado) — el papel de imprenta ya trae encabezado,
+  numeración y CAI. No se pide CAI y Odoo solo imprime el contenido variable,
+  numerando según las hojas consumidas.
 
 Qué agrega
 ==========
 
-* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): indica si el tipo de
-  operación es preimpreso (tiene documento de remito y no tiene CAI).
+* ``stock.picking.type.l10n_ar_autoprinted``: casillero *Autoimpreso* (por
+  defecto verdadero). Al destildarlo, el CAI deja de pedirse y aparecen los
+  *Renglones por Remito*.
+* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): verdadero cuando hay
+  documento de remito y el tipo **no** es autoimpreso. Lo usan el reporte y la
+  numeración.
 * ``stock.picking.type.l10n_ar_lines_per_voucher``: renglones que entran en cada
   hoja preimpresa. Se usa para calcular cuántos números consume una entrega
   larga. Si es 0, cada entrega consume un único número.
@@ -57,7 +60,7 @@ En *Inventario > Configuración > Tipos de operación*, para un tipo de operaci�
 de salida:
 
 #. Definir el *Tipo de documento* de remito.
-#. Dejar el *CAI* vacío (así el tipo pasa a preimpreso).
+#. Destildar *Autoimpreso* (así el tipo pasa a preimpreso).
 #. Opcionalmente cargar *Renglones por Remito*.
 
 Credits

--- a/l10n_ar_stock_preprinted/__init__.py
+++ b/l10n_ar_stock_preprinted/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_stock_preprinted/__manifest__.py
+++ b/l10n_ar_stock_preprinted/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Remito Preimpreso para Argentina",
+    "version": "19.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Soporte de remitos preimpresos de imprenta (con CAI y numeración en el papel)",
+    "depends": [
+        "l10n_ar_stock_ux",
+    ],
+    "data": [
+        "views/stock_picking_type_views.xml",
+        "views/report_deliveryslip.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/l10n_ar_stock_preprinted/models/__init__.py
+++ b/l10n_ar_stock_preprinted/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking_type
+from . import stock_picking

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,0 +1,45 @@
+import math
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    l10n_ar_is_preprinted = fields.Boolean(
+        related="picking_type_id.l10n_ar_is_preprinted",
+    )
+
+    def _l10n_ar_get_voucher_count(self):
+        """Cantidad de comprobantes preimpresos (hojas) que consume la entrega.
+
+        Cada hoja preimpresa trae su propio número; una entrega con más renglones de los que
+        entran en una hoja consume varios números. Se calcula como el techo de
+        (renglones a imprimir / renglones por hoja del tipo de operación). Si no se configuró
+        ``l10n_ar_lines_per_voucher``, la entrega consume un único número.
+        """
+        self.ensure_one()
+        lines_per_voucher = self.picking_type_id.l10n_ar_lines_per_voucher
+        line_count = len(self.move_ids.filtered(lambda m: m.product_uom_qty))
+        if not lines_per_voucher or not line_count:
+            return 1
+        return math.ceil(line_count / lines_per_voucher)
+
+    def l10n_ar_action_create_delivery_guide(self):
+        """En remitos preimpresos numeramos según las hojas consumidas (varios números
+        separados por coma) y sin datos de CAI (el CAI viene impreso en el papel). En
+        autoimpresos se delega al flujo estándar de Odoo (un número + datos de CAI)."""
+        self.ensure_one()
+        if self.l10n_ar_is_preprinted:
+            if not self.l10n_ar_delivery_guide_number:
+                picking_type = self.picking_type_id
+                picking_type._ensure_l10n_ar_stock_sequence()
+                count = self._l10n_ar_get_voucher_count()
+                numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(count)]
+                self.l10n_ar_delivery_guide_number = ",".join(numbers)
+                # guardamos solo el tipo de documento; el CAI no aplica (viene preimpreso)
+                self.l10n_ar_cai_data = {
+                    "document_type_id": picking_type.l10n_ar_document_type_id.id,
+                }
+            return
+        return super().l10n_ar_action_create_delivery_guide()

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,3 +1,4 @@
+import re
 from io import BytesIO
 
 from odoo import fields, models
@@ -10,10 +11,46 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_is_preprinted",
     )
 
+    def _l10n_ar_count_pages_with_products(self, pdf_reader):
+        """Cuenta las páginas del PDF que realmente contienen líneas de producto,
+        analizando el texto de cada hoja: una hoja que solo trae firma o totales NO
+        consume número de remito. La detección usa los identificadores del producto
+        (código interno / código de barras) para ser independiente del idioma; si el
+        producto no tiene código, cae a un patrón numérico genérico (cantidad/precio
+        con decimales)."""
+        self.ensure_one()
+        move_lines = self.move_line_ids or self.move_ids
+        identifiers = set()
+        for line in move_lines:
+            product = line.product_id
+            if product.default_code:
+                identifiers.add(product.default_code.lower().strip())
+            if product.barcode:
+                identifiers.add(product.barcode.lower().strip())
+
+        pages_with_products = 0
+        for page in pdf_reader.pages:
+            try:
+                text = (page.extract_text() or "").lower()
+            except Exception:
+                # Si no se puede extraer el texto, asumimos que la hoja trae productos.
+                pages_with_products += 1
+                continue
+            if not text:
+                continue
+            if identifiers:
+                has_products = any(identifier in text for identifier in identifiers)
+            else:
+                has_products = bool(re.search(r"\b\d+[.,]\d+\b", text))
+            if has_products:
+                pages_with_products += 1
+        return max(1, pages_with_products)
+
     def _l10n_ar_count_preprinted_sheets(self):
         """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
-        realmente se imprimen con productos. Se obtiene renderizando el comprobante de
-        entrega y contando las páginas del PDF resultante."""
+        realmente se imprimen con productos (las hojas de solo firma/totales no consumen
+        número). Se obtiene renderizando el comprobante de entrega y contando esas páginas
+        del PDF resultante."""
         self.ensure_one()
         try:
             from PyPDF2 import PdfReader
@@ -21,13 +58,17 @@ class StockPicking(models.Model):
             from pypdf import PdfReader
         report = self.env.ref("stock.action_report_delivery")
         pdf_content, _dummy = report.sudo()._render_qweb_pdf(report.id, self.ids)
-        return max(1, len(PdfReader(BytesIO(pdf_content)).pages))
+        return self._l10n_ar_count_pages_with_products(PdfReader(BytesIO(pdf_content)))
 
     def l10n_ar_action_create_delivery_guide(self):
         """En remitos preimpresos numeramos según las hojas realmente impresas (una por
         página del comprobante), con varios números separados por coma y sin datos de CAI
-        (el CAI viene preimpreso en el papel). En autoimpresos se delega al flujo estándar
-        de Odoo (un número + datos de CAI)."""
+        (el CAI viene preimpreso en el papel), y devolvemos la acción de impresión: el
+        botón numera e imprime en un solo paso. Los números NO se imprimen en el PDF (el
+        papel de imprenta ya los trae); solo se registran en el picking. Cuando el método
+        corre desde ``_action_done`` (autoasignación) el retorno se ignora, así que no
+        dispara impresiones automáticas. En autoimpresos se delega al flujo estándar de
+        Odoo (un número + datos de CAI)."""
         self.ensure_one()
         if self.l10n_ar_is_preprinted:
             if not self.l10n_ar_delivery_guide_number:
@@ -40,5 +81,5 @@ class StockPicking(models.Model):
                 self.l10n_ar_cai_data = {
                     "document_type_id": picking_type.l10n_ar_document_type_id.id,
                 }
-            return
+            return self.env.ref("stock.action_report_delivery").report_action(self)
         return super().l10n_ar_action_create_delivery_guide()

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,4 +1,4 @@
-import math
+from io import BytesIO
 
 from odoo import fields, models
 
@@ -10,34 +10,33 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_is_preprinted",
     )
 
-    def _l10n_ar_get_voucher_count(self):
-        """Cantidad de comprobantes preimpresos (hojas) que consume la entrega.
-
-        Cada hoja preimpresa trae su propio número; una entrega con más renglones de los que
-        entran en una hoja consume varios números. Se calcula como el techo de
-        (renglones a imprimir / renglones por hoja del tipo de operación). Si no se configuró
-        ``l10n_ar_lines_per_voucher``, la entrega consume un único número.
-        """
+    def _l10n_ar_count_preprinted_sheets(self):
+        """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
+        realmente se imprimen con productos. Se obtiene renderizando el comprobante de
+        entrega y contando las páginas del PDF resultante."""
         self.ensure_one()
-        lines_per_voucher = self.picking_type_id.l10n_ar_lines_per_voucher
-        line_count = len(self.move_ids.filtered(lambda m: m.product_uom_qty))
-        if not lines_per_voucher or not line_count:
-            return 1
-        return math.ceil(line_count / lines_per_voucher)
+        try:
+            from PyPDF2 import PdfReader
+        except ImportError:
+            from pypdf import PdfReader
+        report = self.env.ref("stock.action_report_delivery")
+        pdf_content, _dummy = report.sudo()._render_qweb_pdf(report.id, self.ids)
+        return max(1, len(PdfReader(BytesIO(pdf_content)).pages))
 
     def l10n_ar_action_create_delivery_guide(self):
-        """En remitos preimpresos numeramos según las hojas consumidas (varios números
-        separados por coma) y sin datos de CAI (el CAI viene impreso en el papel). En
-        autoimpresos se delega al flujo estándar de Odoo (un número + datos de CAI)."""
+        """En remitos preimpresos numeramos según las hojas realmente impresas (una por
+        página del comprobante), con varios números separados por coma y sin datos de CAI
+        (el CAI viene preimpreso en el papel). En autoimpresos se delega al flujo estándar
+        de Odoo (un número + datos de CAI)."""
         self.ensure_one()
         if self.l10n_ar_is_preprinted:
             if not self.l10n_ar_delivery_guide_number:
                 picking_type = self.picking_type_id
                 picking_type._ensure_l10n_ar_stock_sequence()
-                count = self._l10n_ar_get_voucher_count()
-                numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(count)]
+                sheets = self._l10n_ar_count_preprinted_sheets()
+                numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(sheets)]
                 self.l10n_ar_delivery_guide_number = ",".join(numbers)
-                # guardamos solo el tipo de documento; el CAI no aplica (viene preimpreso)
+                # el CAI no aplica al preimpreso (viene impreso en el papel)
                 self.l10n_ar_cai_data = {
                     "document_type_id": picking_type.l10n_ar_document_type_id.id,
                 }

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -6,23 +6,21 @@ class StockPickingType(models.Model):
 
     l10n_ar_autoprinted = fields.Boolean(
         string="Autoimpreso",
-        compute="_compute_l10n_ar_preprinted_flags",
-        help="Argentina: se autocalcula según el CAI. Con CAI cargado el remito es autoimpreso "
-        "(Odoo imprime el comprobante completo: encabezado, número y CAI). Sin CAI es preimpreso "
-        "(el papel de imprenta ya trae encabezado, numeración y CAI; Odoo solo imprime el contenido "
-        "variable y numera según las hojas que se imprimen).",
+        default=True,
+        help="Argentina: cuando está activo el remito es autoimpreso (Odoo imprime el comprobante "
+        "completo: encabezado, número y CAI, y el CAI con su vencimiento son obligatorios). Cuando se "
+        "desactiva el remito es preimpreso: el papel de imprenta ya trae encabezado, numeración y CAI, "
+        "por lo que el CAI deja de pedirse y Odoo solo imprime el contenido variable numerando según "
+        "las hojas que se consumen.",
     )
     l10n_ar_is_preprinted = fields.Boolean(
         string="Remito Preimpreso",
-        compute="_compute_l10n_ar_preprinted_flags",
+        compute="_compute_l10n_ar_is_preprinted",
         help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
-        "configurado y NO tiene CAI (es preimpreso). Lo usan el reporte y la numeración.",
+        "configurado y NO es autoimpreso (es preimpreso). Lo usan el reporte y la numeración.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
-    def _compute_l10n_ar_preprinted_flags(self):
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
+    def _compute_l10n_ar_is_preprinted(self):
         for rec in self:
-            has_doc_type = bool(rec.l10n_ar_document_type_id)
-            has_cai = bool(rec.l10n_ar_cai_authorization_code)
-            rec.l10n_ar_autoprinted = has_doc_type and has_cai
-            rec.l10n_ar_is_preprinted = has_doc_type and not has_cai
+            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -4,14 +4,19 @@ from odoo import api, fields, models
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
+    l10n_ar_autoprinted = fields.Boolean(
+        string="Autoimpreso",
+        default=True,
+        help="Argentina: si está tildado, el remito es autoimpreso: Odoo imprime el comprobante "
+        "completo (encabezado, número y CAI) y por eso el CAI es obligatorio. Si se destilda, el "
+        "remito es preimpreso (el papel de imprenta ya trae encabezado, numeración y CAI): no se "
+        "pide CAI y Odoo solo imprime el contenido variable, numerando según las hojas consumidas.",
+    )
     l10n_ar_is_preprinted = fields.Boolean(
         string="Remito Preimpreso",
         compute="_compute_l10n_ar_is_preprinted",
-        help="Argentina: se considera 'preimpreso' cuando el tipo de operación tiene un tipo de "
-        "documento de remito configurado pero NO tiene CAI cargado. En ese caso el papel del remito "
-        "viene preimpreso de imprenta, ya con su numeración y CAI; Odoo solo imprime el contenido "
-        "variable (sin encabezado, sin CAI y sin número). Si el CAI está cargado se trata de un "
-        "remito autoimpreso y se imprime el comprobante completo.",
+        help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
+        "configurado y NO es autoimpreso. Lo usa el reporte y la numeración.",
     )
     l10n_ar_lines_per_voucher = fields.Integer(
         string="Renglones por Remito",
@@ -21,7 +26,7 @@ class StockPickingType(models.Model):
         "único número.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
     def _compute_l10n_ar_is_preprinted(self):
         for rec in self:
-            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_cai_authorization_code
+            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -6,27 +6,23 @@ class StockPickingType(models.Model):
 
     l10n_ar_autoprinted = fields.Boolean(
         string="Autoimpreso",
-        default=True,
-        help="Argentina: si está tildado, el remito es autoimpreso: Odoo imprime el comprobante "
-        "completo (encabezado, número y CAI) y por eso el CAI es obligatorio. Si se destilda, el "
-        "remito es preimpreso (el papel de imprenta ya trae encabezado, numeración y CAI): no se "
-        "pide CAI y Odoo solo imprime el contenido variable, numerando según las hojas consumidas.",
+        compute="_compute_l10n_ar_preprinted_flags",
+        help="Argentina: se autocalcula según el CAI. Con CAI cargado el remito es autoimpreso "
+        "(Odoo imprime el comprobante completo: encabezado, número y CAI). Sin CAI es preimpreso "
+        "(el papel de imprenta ya trae encabezado, numeración y CAI; Odoo solo imprime el contenido "
+        "variable y numera según las hojas que se imprimen).",
     )
     l10n_ar_is_preprinted = fields.Boolean(
         string="Remito Preimpreso",
-        compute="_compute_l10n_ar_is_preprinted",
+        compute="_compute_l10n_ar_preprinted_flags",
         help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
-        "configurado y NO es autoimpreso. Lo usa el reporte y la numeración.",
-    )
-    l10n_ar_lines_per_voucher = fields.Integer(
-        string="Renglones por Remito",
-        help="Argentina (preimpreso): cantidad de renglones que entran en cada hoja/comprobante "
-        "preimpreso. Se usa para calcular cuántos números de remito consume una entrega larga "
-        "(cada hoja preimpresa tiene su propio número). Si se deja en 0, cada entrega consume un "
-        "único número.",
+        "configurado y NO tiene CAI (es preimpreso). Lo usan el reporte y la numeración.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
-    def _compute_l10n_ar_is_preprinted(self):
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
+    def _compute_l10n_ar_preprinted_flags(self):
         for rec in self:
-            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted
+            has_doc_type = bool(rec.l10n_ar_document_type_id)
+            has_cai = bool(rec.l10n_ar_cai_authorization_code)
+            rec.l10n_ar_autoprinted = has_doc_type and has_cai
+            rec.l10n_ar_is_preprinted = has_doc_type and not has_cai

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -1,0 +1,27 @@
+from odoo import api, fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    l10n_ar_is_preprinted = fields.Boolean(
+        string="Remito Preimpreso",
+        compute="_compute_l10n_ar_is_preprinted",
+        help="Argentina: se considera 'preimpreso' cuando el tipo de operación tiene un tipo de "
+        "documento de remito configurado pero NO tiene CAI cargado. En ese caso el papel del remito "
+        "viene preimpreso de imprenta, ya con su numeración y CAI; Odoo solo imprime el contenido "
+        "variable (sin encabezado, sin CAI y sin número). Si el CAI está cargado se trata de un "
+        "remito autoimpreso y se imprime el comprobante completo.",
+    )
+    l10n_ar_lines_per_voucher = fields.Integer(
+        string="Renglones por Remito",
+        help="Argentina (preimpreso): cantidad de renglones que entran en cada hoja/comprobante "
+        "preimpreso. Se usa para calcular cuántos números de remito consume una entrega larga "
+        "(cada hoja preimpresa tiene su propio número). Si se deja en 0, cada entrega consume un "
+        "único número.",
+    )
+
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
+    def _compute_l10n_ar_is_preprinted(self):
+        for rec in self:
+            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_cai_authorization_code

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- En remitos preimpresos el papel de imprenta ya trae encabezado, numeración y CAI.
+         Por eso, cuando el tipo de operación es preimpreso, el reporte solo imprime el
+         contenido variable: activamos pre_printed_report y suprimimos encabezado y número. -->
+    <template id="report_delivery_document_preprinted"
+              inherit_id="l10n_ar_stock_ux.report_delivery_document">
+
+        <xpath expr="//t[@t-set='pre_printed_report']" position="attributes">
+            <attribute name="t-value">o.l10n_ar_is_preprinted</attribute>
+        </xpath>
+
+        <xpath expr="//t[@t-set='custom_header']" position="attributes">
+            <attribute name="t-value">not o.l10n_ar_is_preprinted and o.company_id.country_id.code == 'AR' and 'l10n_ar.custom_header' or False</attribute>
+        </xpath>
+
+        <xpath expr="//t[@t-set='report_number']" position="attributes">
+            <attribute name="t-value">not o.l10n_ar_is_preprinted and (o.l10n_ar_delivery_guide_number or o.name) or False</attribute>
+        </xpath>
+
+    </template>
+</odoo>

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- En remitos preimpresos el papel de imprenta ya trae encabezado, numeración y CAI.
-         Por eso, cuando el tipo de operación es preimpreso, el reporte solo imprime el
-         contenido variable: activamos pre_printed_report y suprimimos encabezado y número. -->
+         Por eso solo imprimimos el contenido variable: activamos pre_printed_report, que
+         hace que el encabezado de la localización argentina se renderice en blanco dejando
+         únicamente la fecha del comprobante, y vaciamos el pie de página. Mantenemos el
+         encabezado de la loc arg (custom_header) — NO lo ponemos en False — porque hacerlo
+         haría caer el reporte al encabezado estándar de Odoo (logo + datos de la empresa),
+         que es justo lo que no queremos en un remito preimpreso. -->
     <template id="report_delivery_document_preprinted"
               inherit_id="l10n_ar_stock_ux.report_delivery_document">
 
+        <!-- pre_printed_report gobierna el blanqueo del encabezado loc arg y oculta el CAI -->
         <xpath expr="//t[@t-set='pre_printed_report']" position="attributes">
             <attribute name="t-value">o.l10n_ar_is_preprinted</attribute>
         </xpath>
 
-        <xpath expr="//t[@t-set='custom_header']" position="attributes">
-            <attribute name="t-value">not o.l10n_ar_is_preprinted and o.company_id.country_id.code == 'AR' and 'l10n_ar.custom_header' or False</attribute>
-        </xpath>
-
-        <xpath expr="//t[@t-set='report_number']" position="attributes">
-            <attribute name="t-value">not o.l10n_ar_is_preprinted and (o.l10n_ar_delivery_guide_number or o.name) or False</attribute>
+        <!-- En preimpreso el pie queda vacío (sin firma, sin paginador, sin CAI). Lo dejamos
+             truthy pero en blanco para que el layout NO caiga al pie estándar de Odoo. -->
+        <xpath expr="//t[@t-set='custom_footer']" position="after">
+            <t t-if="o.l10n_ar_is_preprinted" t-set="custom_footer">
+                <span/>
+            </t>
         </xpath>
 
     </template>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Habilitamos el caso "preimpreso": tipo de documento de remito SIN CAI.
+         Para eso relajamos el required del CAI (y de los datos que solo aplican al
+         autoimpreso) y agregamos los renglones por remito. -->
+    <record id="view_picking_type_form_preprinted" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.preprinted</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
+        <field name="arch" type="xml">
+            <!-- CAI opcional: su presencia distingue autoimpreso (con CAI) de preimpreso (sin CAI) -->
+            <field name="l10n_ar_cai_authorization_code" position="attributes">
+                <attribute name="required">0</attribute>
+            </field>
+            <!-- estos datos solo son obligatorios cuando hay CAI (autoimpreso) -->
+            <field name="l10n_ar_cai_expiration_date" position="attributes">
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+            </field>
+            <field name="l10n_ar_sequence_number_start" position="attributes">
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+            </field>
+            <field name="l10n_ar_sequence_number_end" position="attributes">
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+            </field>
+            <!-- renglones por hoja: solo aplica al preimpreso (doc type sin CAI) -->
+            <field name="l10n_ar_next_delivery_number" position="after">
+                <field name="l10n_ar_lines_per_voucher"
+                       invisible="not l10n_ar_document_type_id or l10n_ar_cai_authorization_code"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -8,24 +8,31 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- CAI opcional: su presencia distingue autoimpreso (con CAI) de preimpreso (sin CAI) -->
-            <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">0</attribute>
+            <!-- toggle Autoimpreso: define si el remito es autoimpreso (con CAI) o preimpreso -->
+            <field name="l10n_ar_document_type_id" position="after">
+                <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- estos datos solo son obligatorios cuando hay CAI (autoimpreso) -->
+            <!-- el CAI y su rango solo aplican (y son obligatorios) en autoimpreso -->
+            <field name="l10n_ar_cai_authorization_code" position="attributes">
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+            </field>
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
-            <!-- renglones por hoja: solo aplica al preimpreso (doc type sin CAI) -->
+            <!-- renglones por hoja: solo aplica al preimpreso -->
             <field name="l10n_ar_next_delivery_number" position="after">
                 <field name="l10n_ar_lines_per_voucher"
-                       invisible="not l10n_ar_document_type_id or l10n_ar_cai_authorization_code"/>
+                       invisible="not l10n_ar_document_type_id or l10n_ar_autoprinted"/>
             </field>
         </field>
     </record>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,38 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- Habilitamos el caso "preimpreso": tipo de documento de remito SIN CAI.
-         Para eso relajamos el required del CAI (y de los datos que solo aplican al
-         autoimpreso) y agregamos los renglones por remito. -->
+         El casillero Autoimpreso se autocalcula según el CAI (con CAI = autoimpreso).
+         Relajamos la obligatoriedad del CAI y ocultamos sus datos cuando es preimpreso. -->
     <record id="view_picking_type_form_preprinted" model="ir.ui.view">
         <field name="name">stock.picking.type.form.preprinted</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- toggle Autoimpreso: define si el remito es autoimpreso (con CAI) o preimpreso -->
+            <!-- indicador Autoimpreso (solo lectura, computado del CAI) -->
             <field name="l10n_ar_document_type_id" position="after">
                 <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- el CAI y su rango solo aplican (y son obligatorios) en autoimpreso -->
+            <!-- CAI opcional: su presencia define autoimpreso vs preimpreso -->
             <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">0</attribute>
             </field>
+            <!-- vencimiento y rango solo aplican (y son obligatorios) cuando hay CAI -->
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
-            </field>
-            <!-- renglones por hoja: solo aplica al preimpreso -->
-            <field name="l10n_ar_next_delivery_number" position="after">
-                <field name="l10n_ar_lines_per_voucher"
-                       invisible="not l10n_ar_document_type_id or l10n_ar_autoprinted"/>
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
             </field>
         </field>
     </record>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,33 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Habilitamos el caso "preimpreso": tipo de documento de remito SIN CAI.
-         El casillero Autoimpreso se autocalcula según el CAI (con CAI = autoimpreso).
-         Relajamos la obligatoriedad del CAI y ocultamos sus datos cuando es preimpreso. -->
+    <!-- El casillero Autoimpreso gobierna el CAI: al activarlo, el CAI y su vencimiento
+         (y el rango autorizado) se vuelven visibles y obligatorios; al desactivarlo se
+         ocultan y el tipo de operación queda como preimpreso. -->
     <record id="view_picking_type_form_preprinted" model="ir.ui.view">
         <field name="name">stock.picking.type.form.preprinted</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- indicador Autoimpreso (solo lectura, computado del CAI) -->
+            <!-- Autoimpreso: booleano editable, solo relevante en tipos de operación con remito -->
             <field name="l10n_ar_document_type_id" position="after">
                 <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- CAI opcional: su presencia define autoimpreso vs preimpreso -->
+            <!-- CAI: visible y obligatorio solo cuando es autoimpreso -->
             <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">0</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
-            <!-- vencimiento y rango solo aplican (y son obligatorios) cuando hay CAI -->
+            <!-- Vencimiento y rango del CAI: mismo criterio que el CAI -->
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Tarea 71244 — Implementar remito preimpreso (v19)

Reincorpora el soporte de **remitos preimpresos de imprenta** sobre el flujo de remitos argentinos de `l10n_ar_stock` / `l10n_ar_stock_ux`.

Un remito preimpreso es papel provisto por una imprenta que ya trae impresos el encabezado, la numeración y el CAI; Odoo solo imprime el contenido variable y numera según las hojas que consume.

### `l10n_ar_stock_preprinted`
- El modo se **deriva del tipo de operación**, sin campos nuevos que el usuario deba marcar:
  - **Autoimpreso** — el tipo de operación tiene CAI → comprobante completo + un número (comportamiento estándar).
  - **Preimpreso** — tiene tipo de documento de remito pero **no** tiene CAI → se habilita relajando la obligatoriedad del CAI.
- `stock.picking.type.l10n_ar_is_preprinted` (computado) y `l10n_ar_lines_per_voucher` (renglones por hoja).
- Numeración: en preimpreso se asignan tantos números consecutivos como hojas consuma la entrega (`ceil(renglones / renglones_por_hoja)`), coma-separados y sin datos de CAI.
- Reporte: en preimpreso se imprime sin encabezado, sin número y sin CAI (ya vienen en el papel).

### `l10n_ar_stock_picking_batch_preprinted`
- Módulo puente (`auto_install`) con `l10n_ar_stock_picking_batch`: en un lote preimpreso el remito consolida las líneas de todas las transferencias, por lo que numera sobre el total de renglones del lote.

### Pendientes
- Validar convivencia con impresión IoT (imprimir una sola vez).
- Tests automatizados y traducciones (i18n).