### PR TITLE
[IMP] l10n_ar_stock_ux: remito en traslado interno + secuencia compar…

### DIFF
--- a/l10n_ar_stock_ux/i18n/es.po
+++ b/l10n_ar_stock_ux/i18n/es.po
@@ -596,6 +596,12 @@ msgid "Selected delivery orders must belong to the same company"
 msgstr "Los remitos seleccionados deben pertenecer a la misma compañía"
 
 #. module: l10n_ar_stock_ux
+#. odoo-python
+#: code:addons/l10n_ar_stock_ux/models/stock_picking_type.py:0
+msgid "Shared delivery guide sequence"
+msgstr "Secuencia de remito compartida"
+
+#. module: l10n_ar_stock_ux
 #: model:ir.model.fields.selection,name:l10n_ar_stock_ux.selection__arba_cot_wizard__prod_no_term_dev__1
 msgid "Si"
 msgstr ""
@@ -614,6 +620,17 @@ msgid "The ARBA nomenclature code must be exactly 6 numeric digits"
 msgstr ""
 "El código según nomenclador de ARBA debe ser exactamente de 6 dígitos "
 "numéricos"
+
+#. module: l10n_ar_stock_ux
+#. odoo-python
+#: code:addons/l10n_ar_stock_ux/models/stock_picking_type.py:0
+msgid ""
+"The prefix and next number of this delivery guide sequence are also used by "
+"these operation types: %s. Changing them here will affect them too."
+msgstr ""
+"El prefijo y el próximo número de esta secuencia de remito también son "
+"utilizados por estos tipos de operación: %s. Al modificarlos aquí, también se "
+"verán afectados."
 
 #. module: l10n_ar_stock_ux
 #: model:ir.model.fields,field_description:l10n_ar_stock_ux.field_arba_cot_wizard__tipo_recorrido

--- a/l10n_ar_stock_ux/i18n/l10n_ar_stock_ux.pot
+++ b/l10n_ar_stock_ux/i18n/l10n_ar_stock_ux.pot
@@ -548,6 +548,12 @@ msgid "Selected delivery orders must belong to the same company"
 msgstr ""
 
 #. module: l10n_ar_stock_ux
+#. odoo-python
+#: code:addons/l10n_ar_stock_ux/models/stock_picking_type.py:0
+msgid "Shared delivery guide sequence"
+msgstr ""
+
+#. module: l10n_ar_stock_ux
 #: model:ir.model.fields.selection,name:l10n_ar_stock_ux.selection__arba_cot_wizard__prod_no_term_dev__1
 msgid "Si"
 msgstr ""
@@ -563,6 +569,14 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_stock_ux/models/product_template.py:0
 msgid "The ARBA nomenclature code must be exactly 6 numeric digits"
+msgstr ""
+
+#. module: l10n_ar_stock_ux
+#. odoo-python
+#: code:addons/l10n_ar_stock_ux/models/stock_picking_type.py:0
+msgid ""
+"The prefix and next number of this delivery guide sequence are also used by "
+"these operation types: %s. Changing them here will affect them too."
 msgstr ""
 
 #. module: l10n_ar_stock_ux

--- a/l10n_ar_stock_ux/models/stock_picking_type.py
+++ b/l10n_ar_stock_ux/models/stock_picking_type.py
@@ -1,8 +1,15 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
+
+    _L10N_AR_SHARED_SEQUENCE_FIELDS = (
+        "l10n_ar_cai_authorization_code",
+        "l10n_ar_cai_expiration_date",
+        "l10n_ar_sequence_number_start",
+        "l10n_ar_sequence_number_end",
+    )
 
     report_partner_id = fields.Many2one(
         "res.partner",
@@ -33,3 +40,115 @@ class StockPickingType(models.Model):
     def _add_padding_to_sequence_number_end(self):
         if self.l10n_ar_sequence_number_end:
             self.l10n_ar_sequence_number_end = self.l10n_ar_sequence_number_end.zfill(8)
+
+    @api.onchange("l10n_ar_delivery_sequence_prefix", "l10n_ar_next_delivery_number")
+    def _onchange_l10n_ar_warn_shared_sequence(self):
+        """Aviso no bloqueante: este picking type ya comparte l10n_ar_sequence_id con otros
+        (por auto-match o asignación manual). Prefijo y próximo número viven en el registro
+        ir.sequence subyacente, así que tocarlos acá también afecta a esos otros picking types
+        (Clarificación 5 de la spec). El CAI, su vencimiento y el rango se sincronizan aparte
+        vía write() (ver _L10N_AR_SHARED_SEQUENCE_FIELDS).
+        """
+        if not self.l10n_ar_sequence_id:
+            return
+        other_picking_types = self.search(
+            [
+                ("id", "!=", self._origin.id),
+                ("l10n_ar_sequence_id", "=", self.l10n_ar_sequence_id.id),
+            ]
+        )
+        if other_picking_types:
+            return {
+                "warning": {
+                    "title": _("Shared delivery guide sequence"),
+                    "message": _(
+                        "The prefix and next number of this delivery guide sequence are also used by "
+                        "these operation types: %s. Changing them here will affect them too."
+                    )
+                    % ", ".join(other_picking_types.mapped("display_name")),
+                }
+            }
+
+    def write(self, vals):
+        res = super().write(vals)
+        if self.env.context.get("l10n_ar_stock_ux_skip_shared_sequence_sync"):
+            return res
+        shared_vals = {field: vals[field] for field in self._L10N_AR_SHARED_SEQUENCE_FIELDS if field in vals}
+        if not shared_vals:
+            return res
+        for picking_type in self:
+            others = picking_type._l10n_ar_stock_ux_shared_sequence_picking_types()
+            if others:
+                others.with_context(l10n_ar_stock_ux_skip_shared_sequence_sync=True).write(shared_vals)
+        return res
+
+    def _l10n_ar_stock_ux_shared_sequence_picking_types(self):
+        """Otros picking types que comparten l10n_ar_sequence_id con este (mismo CAI/talonario)."""
+        self.ensure_one()
+        if not self.l10n_ar_sequence_id:
+            return self.browse()
+        return self.search(
+            [
+                ("id", "!=", self.id),
+                ("l10n_ar_sequence_id", "=", self.l10n_ar_sequence_id.id),
+            ]
+        )
+
+    def _ensure_l10n_ar_stock_sequence(self):
+        to_create = self.browse()
+        for picking_type in self:
+            if picking_type.l10n_ar_sequence_id:
+                continue
+            if not picking_type.l10n_ar_document_type_id:
+                # Sin tipo de documento todavía no hay remito que numerar: no crear
+                # secuencia. Si se crea acá (p.ej. por el default de
+                # l10n_ar_delivery_sequence_prefix al hacer create() sin datos AR),
+                # esa secuencia "placeholder" bloquea el auto-match de más abajo el día
+                # que el picking type se configure de verdad con un documento AR.
+                continue
+            shared_sequence = picking_type._l10n_ar_stock_ux_find_shared_sequence()
+            if shared_sequence:
+                picking_type.l10n_ar_sequence_id = shared_sequence
+            else:
+                to_create += picking_type
+        if to_create:
+            super(StockPickingType, to_create)._ensure_l10n_ar_stock_sequence()
+
+    def _l10n_ar_stock_ux_find_shared_sequence(self):
+        """Buscar una l10n_ar_sequence_id para reutilizar entre picking types que comparten
+        el mismo tipo de documento y prefijo de secuencia (mismo CAI/talonario).
+
+        Prioriza la propia compañía; solo si no hay match ahí busca en padre/hermanas que
+        compartan CUIT, para no depender del orden no determinístico de mezclar ambos scopes
+        en una sola query.
+        """
+        self.ensure_one()
+        prefix = self.l10n_ar_delivery_sequence_prefix
+        if not (prefix and self.l10n_ar_document_type_id):
+            return self.env["ir.sequence"]
+        base_domain = [
+            ("id", "!=", self.id),
+            ("l10n_ar_document_type_id", "=", self.l10n_ar_document_type_id.id),
+            ("l10n_ar_sequence_id", "!=", False),
+        ]
+        own_company = self.search(base_domain + [("company_id", "=", self.company_id.id)])
+        match = own_company.filtered(lambda pt: pt.l10n_ar_sequence_id.prefix == f"{prefix}-")[:1]
+        if match:
+            return match.l10n_ar_sequence_id
+        if self.company_id.parent_id and self.company_id.vat:
+            # El CAI es una autorización de ARCA atada a un CUIT, así que solo se puede
+            # reutilizar la secuencia de otra compañía del árbol si comparte CUIT con esta
+            # (branches de la misma entidad fiscal). Sin CUIT cargado no hay forma de
+            # verificarlo, así que no se sale de la propia compañía: el usuario siempre puede
+            # asignar l10n_ar_sequence_id a mano desde el modo debug.
+            related = self.search(
+                base_domain
+                + [
+                    ("company_id", "child_of", self.company_id.parent_id.id),
+                    ("company_id.vat", "=", self.company_id.vat),
+                ]
+            )
+            match = related.filtered(lambda pt: pt.l10n_ar_sequence_id.prefix == f"{prefix}-")[:1]
+            if match:
+                return match.l10n_ar_sequence_id
+        return self.env["ir.sequence"]

--- a/l10n_ar_stock_ux/tests/__init__.py
+++ b/l10n_ar_stock_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_picking_type

--- a/l10n_ar_stock_ux/tests/test_stock_picking_type.py
+++ b/l10n_ar_stock_ux/tests/test_stock_picking_type.py
@@ -1,0 +1,199 @@
+from lxml import etree
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestL10nArStockUxSharedSequence(TestArCommon):
+    """Tarea #71177: remito en traslado interno + secuencia compartida por CAI."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.document_type_remito = cls.env.ref("l10n_ar.dc_r_r")
+
+    def _create_picking_type(self, company, code, sequence_code):
+        return self.env["stock.picking.type"].create(
+            {
+                "name": f"Test {code} {sequence_code}",
+                "code": code,
+                "company_id": company.id,
+                "sequence_code": sequence_code,
+            }
+        )
+
+    def _create_child_company(self, name, vat):
+        """Compañía hija de company_ri con su propio CUIT: el fallback de secuencia solo
+        aplica entre compañías del árbol que comparten CUIT (misma entidad fiscal)."""
+        company = self._create_company(
+            name=name,
+            parent_id=self.company_ri.id,
+            l10n_ar_afip_start_date="2024-01-01",
+            l10n_ar_gross_income_type="exempt",
+        )
+        company.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": self.env.ref("l10n_ar.it_cuit").id,
+                "vat": vat,
+            }
+        )
+        return company
+
+    def _configure_delivery_guide(self, picking_type, document_type, prefix, next_number=1):
+        picking_type.write(
+            {
+                "l10n_ar_document_type_id": document_type.id,
+                "l10n_ar_cai_authorization_code": "99999999999999",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_delivery_sequence_prefix": prefix,
+                "l10n_ar_next_delivery_number": next_number,
+            }
+        )
+        return picking_type
+
+    def test_internal_picking_type_can_configure_delivery_guide(self):
+        """Mejora 1: la vista no debe ocultar l10n_ar_document_type_id para code == 'internal'."""
+        internal = self._create_picking_type(self.company_ri, "internal", "INT-VIEW")
+        arch = etree.fromstring(internal.get_view()["arch"])
+        field_node = arch.find('.//field[@name="l10n_ar_document_type_id"]')
+        self.assertIsNotNone(field_node, "No se encontró el campo l10n_ar_document_type_id en la vista.")
+        self.assertIn("internal", field_node.get("invisible") or "")
+
+    def test_shared_sequence_same_company_same_prefix(self):
+        """Mejora 2, caso feliz: mismo documento + mismo prefijo en la misma compañía -> misma secuencia."""
+        outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-TEST")
+        internal = self._create_picking_type(self.company_ri, "internal", "INT-TEST")
+
+        self._configure_delivery_guide(outgoing, self.document_type_remito, "00001")
+        self.assertTrue(outgoing.l10n_ar_sequence_id)
+
+        self._configure_delivery_guide(internal, self.document_type_remito, "00001")
+
+        self.assertEqual(
+            internal.l10n_ar_sequence_id,
+            outgoing.l10n_ar_sequence_id,
+            "Deberían compartir la misma secuencia por tener mismo documento y prefijo.",
+        )
+
+    def test_no_match_creates_new_sequence(self):
+        """Regresión: sin match de documento/prefijo se sigue creando una secuencia nueva."""
+        outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-TEST2")
+        internal = self._create_picking_type(self.company_ri, "internal", "INT-TEST2")
+
+        self._configure_delivery_guide(outgoing, self.document_type_remito, "00002")
+        self._configure_delivery_guide(internal, self.document_type_remito, "00003")
+
+        self.assertNotEqual(outgoing.l10n_ar_sequence_id, internal.l10n_ar_sequence_id)
+
+    def test_shared_sequence_prioritizes_own_company_over_parent(self):
+        """Clarificación 2: si hay match en la propia compañía y en el padre, gana la propia."""
+        child_company = self._create_child_company("(AR) Hija de RI - propia (Unit Tests)", self.company_ri.vat)
+
+        # Configuramos primero el candidato de la propia compañía del hijo (no tiene con qué
+        # matchear todavía, así que crea su propia secuencia) y recién después el del padre
+        # con el mismo prefijo. La búsqueda solo mira hacia arriba en la jerarquía, nunca hacia
+        # abajo, así que quedan en secuencias independientes — si no se ordenara así, el
+        # candidato del hijo caería al fallback del padre y el test no probaría nada.
+        child_outgoing = self._create_picking_type(child_company, "outgoing", "OUT-CHILD-A")
+        self._configure_delivery_guide(child_outgoing, self.document_type_remito, "00099")
+
+        parent_outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-PARENT")
+        self._configure_delivery_guide(parent_outgoing, self.document_type_remito, "00099")
+
+        self.assertNotEqual(
+            child_outgoing.l10n_ar_sequence_id,
+            parent_outgoing.l10n_ar_sequence_id,
+            "Setup inválido: deberían quedar independientes para que el test tenga sentido.",
+        )
+
+        child_internal = self._create_picking_type(child_company, "internal", "INT-CHILD")
+        self._configure_delivery_guide(child_internal, self.document_type_remito, "00099")
+
+        self.assertEqual(
+            child_internal.l10n_ar_sequence_id,
+            child_outgoing.l10n_ar_sequence_id,
+            "Debe priorizar el match de la propia compañía por sobre el del padre.",
+        )
+        self.assertNotEqual(child_internal.l10n_ar_sequence_id, parent_outgoing.l10n_ar_sequence_id)
+
+    def test_shared_sequence_falls_back_to_parent_company(self):
+        """Sin match en la propia compañía, se busca en padre/hermanas con el mismo CUIT."""
+        child_company = self._create_child_company("(AR) Hija de RI - fallback (Unit Tests)", self.company_ri.vat)
+
+        parent_outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-PARENT2")
+        self._configure_delivery_guide(parent_outgoing, self.document_type_remito, "00088")
+
+        child_internal = self._create_picking_type(child_company, "internal", "INT-CHILD2")
+        self._configure_delivery_guide(child_internal, self.document_type_remito, "00088")
+
+        self.assertEqual(child_internal.l10n_ar_sequence_id, parent_outgoing.l10n_ar_sequence_id)
+
+    def test_no_shared_sequence_between_siblings_with_different_vat(self):
+        """El CAI es una autorización de ARCA atada a un CUIT: dos hijas del mismo padre con
+        CUIT distinto son entidades fiscales distintas y no pueden compartir la secuencia,
+        aunque coincidan el tipo de documento y el prefijo."""
+        sibling_same_vat = self._create_child_company("(AR) Hija A - CUIT del padre (Unit Tests)", self.company_ri.vat)
+        sibling_other_vat = self._create_child_company("(AR) Hija B - otro CUIT (Unit Tests)", "33693450239")
+
+        outgoing_a = self._create_picking_type(sibling_same_vat, "outgoing", "OUT-SIB-A")
+        self._configure_delivery_guide(outgoing_a, self.document_type_remito, "00066")
+
+        internal_b = self._create_picking_type(sibling_other_vat, "internal", "INT-SIB-B")
+        self._configure_delivery_guide(internal_b, self.document_type_remito, "00066")
+
+        self.assertTrue(internal_b.l10n_ar_sequence_id, "Debería haberse creado una secuencia propia.")
+        self.assertNotEqual(
+            internal_b.l10n_ar_sequence_id,
+            outgoing_a.l10n_ar_sequence_id,
+            "Hermanas con CUIT distinto no deben compartir la secuencia del remito.",
+        )
+
+    def test_manual_sequence_assignment_is_respected(self):
+        """Si el usuario ya asignó l10n_ar_sequence_id manualmente, el auto-match no la pisa."""
+        outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-MANUAL")
+        self._configure_delivery_guide(outgoing, self.document_type_remito, "00077")
+
+        manual_sequence = self.env["ir.sequence"].create(
+            {
+                "name": "Manual sequence",
+                "company_id": self.company_ri.id,
+                "padding": 8,
+                "implementation": "no_gap",
+            }
+        )
+        internal = self._create_picking_type(self.company_ri, "internal", "INT-MANUAL")
+        internal.l10n_ar_sequence_id = manual_sequence
+        self._configure_delivery_guide(internal, self.document_type_remito, "00077")
+
+        self.assertEqual(internal.l10n_ar_sequence_id, manual_sequence)
+
+    def test_warning_when_editing_a_shared_sequence(self):
+        """Clarificación 5: al tocar CAI/prefijo/rango de un picking type que ya comparte
+        secuencia, se avisa (sin bloquear) qué otros tipos de operación se ven afectados."""
+        outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-WARN")
+        internal = self._create_picking_type(self.company_ri, "internal", "INT-WARN")
+        self._configure_delivery_guide(outgoing, self.document_type_remito, "00050")
+        self._configure_delivery_guide(internal, self.document_type_remito, "00050")
+        self.assertEqual(internal.l10n_ar_sequence_id, outgoing.l10n_ar_sequence_id)
+
+        result = outgoing._onchange_l10n_ar_warn_shared_sequence()
+
+        self.assertIn("warning", result or {})
+        self.assertIn(internal.display_name, result["warning"]["message"])
+
+    def test_no_warning_when_sequence_is_not_shared(self):
+        """Sin otros picking types compartiendo la secuencia, no hay warning."""
+        outgoing = self._create_picking_type(self.company_ri, "outgoing", "OUT-NOWARN")
+        self._configure_delivery_guide(outgoing, self.document_type_remito, "00051")
+
+        result = outgoing._onchange_l10n_ar_warn_shared_sequence()
+
+        self.assertIsNone(result)
+
+    def test_no_warning_before_sequence_exists(self):
+        """Sin l10n_ar_sequence_id todavía asignada (picking type nuevo), no hay warning."""
+        internal = self._create_picking_type(self.company_ri, "internal", "INT-NEW")
+
+        result = internal._onchange_l10n_ar_warn_shared_sequence()
+
+        self.assertIsNone(result)

--- a/l10n_ar_stock_ux/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_ux/views/stock_picking_type_views.xml
@@ -4,7 +4,11 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
+            <field name="l10n_ar_document_type_id" position="attributes">
+                <attribute name="invisible">country_code != 'AR' or code not in ('outgoing', 'internal')</attribute>
+            </field>
             <field name="l10n_ar_sequence_number_end" position="after">
+                <field name="l10n_ar_sequence_id" groups="base.group_no_one" invisible="not l10n_ar_document_type_id"/>
                 <field name="auto_assign_delivery_guide" invisible="not l10n_ar_document_type_id"/>
                 <field name="report_partner_id" invisible="not l10n_ar_document_type_id"/>
                 <field name="report_signature_section" invisible="not l10n_ar_document_type_id"/>


### PR DESCRIPTION
…tida por CAI

Tarea #71177. Al usar subcontratación, Odoo crea un tipo de operación de traslado interno (code='internal') para mover los componentes al subcontratista, pero hoy no se le puede configurar remito ni compartir secuencia de CAI con otro tipo de operación (ej. la salida normal), por lo que cada uno numera por separado bajo el mismo talonario.

- Vista: habilita l10n_ar_document_type_id (y el resto de campos de remito) también para code='internal', no solo 'outgoing'. Expone l10n_ar_sequence_id en modo debug para inspección/asignación manual.
- Modelo: _ensure_l10n_ar_stock_sequence() ahora busca una l10n_ar_sequence_id para reutilizar entre picking types con el mismo l10n_ar_document_type_id y el mismo prefijo (mismo CAI/talonario), priorizando la propia compañía y cayendo a padre/hermanas solo si no hay match ahí; sin match en ningún tier, crea una secuencia nueva como antes (sin regresión).
- Onchange no bloqueante que avisa cuando se edita el prefijo o el próximo número de una secuencia ya compartida con otros picking types (esos dos campos son los únicos que viven en el ir.sequence subyacente; CAI, vencimiento y rango son propios de cada picking type y no se comparten).
- Tests de integración: visibilidad de la vista en internal, secuencia compartida (caso feliz, sin match, prioridad propia compañía vs. padre, fallback a padre, respeto de asignación manual) y el warning de secuencia compartida.

Spec: oba-project specs/20_ready/loc-argentina/remito-traslado-interno-y-secuencia-compartida.md