### PR TITLE
[FIX] l10n_ar_stock_ux: add delivery guide number to shipping label

### DIFF
--- a/l10n_ar_stock_ux/__manifest__.py
+++ b/l10n_ar_stock_ux/__manifest__.py
@@ -28,6 +28,7 @@
         "views/stock_lot_views.xml",
         "views/report_deliveryslip.xml",
         "views/report_invoice.xml",
+        "views/picking_templates.xml",
         "data/ir_sequence_data.xml",
         "data/product_uom_data.xml",
         "security/ir.model.access.csv",

--- a/l10n_ar_stock_ux/views/picking_templates.xml
+++ b/l10n_ar_stock_ux/views/picking_templates.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <!-- Agregamos el número de remito a la etiqueta de despacho de stock_ux.
+         En v18 este dato lo agregaba stock_voucher (discontinuado en v19) desde
+         picking.voucher_ids; en v19 el dato vive en el campo
+         l10n_ar_delivery_guide_number de la localización argentina. -->
+
+    <template
+        id="custom_label_transfer_template_view_pdf"
+        inherit_id="stock_ux.custom_label_transfer_template_view_pdf"
+    >
+        <xpath expr="//div[t[@t-out='picking.origin']]" position="after">
+            <div t-if="picking.l10n_ar_delivery_guide_number" style="font-weight: normal;">Remito/s:
+                <t t-out="picking.l10n_ar_delivery_guide_number" />
+            </div>
+        </xpath>
+    </template>
+
+    <template
+        id="custom_label_transfer_template_view_zpl"
+        inherit_id="stock_ux.custom_label_transfer_template_view_zpl"
+    >
+        <xpath expr="//t[@t-esc='picking.origin']" position="after"><t t-if="picking.l10n_ar_delivery_guide_number">^FS ^CFJ,25 ^FO50,720^FDRemito:^FS ^CF0,28 ^FO160,720^FD<t t-esc="picking.l10n_ar_delivery_guide_number" /></t></xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
## Problem

The shipping label ("Etiqueta de despacho", PDF and ZPL) stopped printing the delivery guide number after migrating from 18.0 to 19.0.

It is not a regression of a single template: in 18.0 the report was provided by `stock_voucher`, which printed `picking.voucher_ids`. That module does not exist in 19.0, and the report was moved into `stock_ux` (commit `ef16192f`) without the delivery guide block — the source field was gone. So in 19.0 the only label bound to `stock.picking` is `stock_ux.custom_label_transfer_template_view_pdf` / `_view_zpl`, and neither prints it.

The data is available in 19.0: `stock.picking.l10n_ar_delivery_guide_number`, defined in `l10n_ar_stock_ux`.

## Approach

Inherit both `stock_ux` templates by xpath from `l10n_ar_stock_ux` and add the "Remito/s:" block.

`stock_ux` itself is deliberately **not** modified: `l10n_ar_delivery_guide_number` does not exist on non-Argentinian databases, so adding it there would break the label for every other client. Inheriting (instead of declaring a replacement report) also avoids duplicating the "Etiqueta de despacho" print action.

It lives in `l10n_ar_stock_ux` rather than `l10n_ar_stock_delivery` because that is where the field is defined, it already depends on `stock_ux`, and it is `auto_install` of `l10n_ar_stock` — so every AR client gets it, not only the ones using `delivery_ux`.

The block is wrapped in `t-if` on the field, so pickings without a delivery guide render byte-identical to today.

### Note on the ZPL xpath

In the ZPL template the `^FS` that closes the `Orden:` field is the tail of the `<t t-esc="picking.origin"/>` node, and view inheritance emits that tail *after* the inserted nodes. That is why the inserted block opens with `^FS` and has no trailing `^FS`, and why it is written on a single line (otherwise the indentation whitespace ends up inside the `^FD` data field). Resulting stream, which matches the 18.0 structure:

```
^CF0,28 ^FO160,680^FD{origin}^FS ^CFJ,25 ^FO50,720^FDRemito:^FS ^CF0,28 ^FO160,720^FD{guide}^FS
```

The Spanish literals ("Remito/s:", "Remito:") follow the surrounding template, which is entirely hardcoded Spanish inside `t-translation="off"`, and match the 18.0 output the users expect.

## Test plan

On a 19.0 build with `l10n_ar_stock_ux` installed:

1. Picking **with** `l10n_ar_delivery_guide_number` set → print "Etiqueta de despacho (PDF)": the guide number shows below `Orden:`. Same for the ZPL variant.
2. Picking **without** the field set → both variants render as before, with no empty "Remito/s:" line.
3. Only one "Etiqueta de despacho (PDF)" / "(ZPL)" entry in the print menu (no duplicated action).

Merge needs `bump` — the PR adds a data XML file, so the module must be updated on deploy.
