### PR TITLE
[FIX] l10n_ar_stock_ux: use AR delivery report for all AR pickings

### DIFF
--- a/l10n_ar_stock_ux/models/stock_picking.py
+++ b/l10n_ar_stock_ux/models/stock_picking.py
@@ -71,7 +71,7 @@ class StockPicking(models.Model):
         Another option would be to use report_substitute module and setup a subsitution with a domain
         """
         self.ensure_one()
-        if self.company_id.country_id.code == "AR" and self.l10n_ar_delivery_guide_number:
+        if self.company_id.country_id.code == "AR":
             return "l10n_ar_stock_ux.report_delivery_document"
         return report_xml_id
 


### PR DESCRIPTION
Previously the Argentine delivery report was only selected when a delivery guide number had been assigned, so validated AR pickings without a guide fell back to Odoo's native delivery note. Restore v18 behavior: use the AR "Comprobante de Entrega" format for any AR company picking (task 71442).