### PR TITLE
[ADD] l10n_ar_stock_preprinted: remito preimpreso, variante con un solo campo de modo (tarea 71244)

### DIFF
--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -10,9 +10,9 @@
    :target: https://www.gnu.org/licenses/agpl
    :alt: License: AGPL-3
 
-===============================
+==================================
 Remito Preimpreso para Argentina
-===============================
+==================================
 
 Reincorpora el soporte de **remitos preimpresos de imprenta** sobre el flujo de
 remitos argentinos de ``l10n_ar_stock`` / ``l10n_ar_stock_ux``.

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -19,37 +19,32 @@ remitos argentinos de ``l10n_ar_stock`` / ``l10n_ar_stock_ux``.
 
 Un remito preimpreso es papel provisto por una imprenta que ya trae impresos el
 encabezado, la numeración y el CAI. En ese caso Odoo solo imprime el contenido
-variable (productos, cliente) y numera las transferencias según los comprobantes
-(hojas) que consume.
+variable (productos, cliente) y numera la entrega según las hojas que realmente
+se imprimen.
 
 Cómo se distingue del autoimpreso
 =================================
 
-Un casillero **Autoimpreso** en el tipo de operación define el modo:
+El modo se **autocalcula según el CAI** del tipo de operación:
 
-* **Autoimpreso** (tildado) — Odoo imprime el comprobante completo (encabezado,
-  número y CAI); el CAI es obligatorio. Se numera con un único número por
-  transferencia (comportamiento estándar de ``l10n_ar_stock``).
-* **Preimpreso** (destildado) — el papel de imprenta ya trae encabezado,
-  numeración y CAI. No se pide CAI y Odoo solo imprime el contenido variable,
-  numerando según las hojas consumidas.
+* **Autoimpreso** — el tipo de operación tiene CAI cargado. Odoo imprime el
+  comprobante completo (encabezado, número y CAI) y numera con un único número
+  por transferencia (comportamiento estándar de ``l10n_ar_stock``).
+* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
+  pero **no** tiene CAI. Este módulo habilita ese caso relajando la
+  obligatoriedad del CAI.
 
 Qué agrega
 ==========
 
-* ``stock.picking.type.l10n_ar_autoprinted``: casillero *Autoimpreso* (por
-  defecto verdadero). Al destildarlo, el CAI deja de pedirse y aparecen los
-  *Renglones por Remito*.
+* ``stock.picking.type.l10n_ar_autoprinted`` (computado): casillero *Autoimpreso*
+  de solo lectura; verdadero cuando hay CAI cargado.
 * ``stock.picking.type.l10n_ar_is_preprinted`` (computado): verdadero cuando hay
-  documento de remito y el tipo **no** es autoimpreso. Lo usan el reporte y la
-  numeración.
-* ``stock.picking.type.l10n_ar_lines_per_voucher``: renglones que entran en cada
-  hoja preimpresa. Se usa para calcular cuántos números consume una entrega
-  larga. Si es 0, cada entrega consume un único número.
-* Numeración: al generar la guía de remito en un tipo preimpreso, se asignan
-  tantos números consecutivos como hojas consuma la entrega
-  (``ceil(renglones / renglones_por_hoja)``), separados por coma, sin datos de
-  CAI.
+  documento de remito y no hay CAI. Lo usan el reporte y la numeración.
+* Numeración: al generar la guía de remito en un tipo preimpreso, se renderiza el
+  comprobante de entrega, se cuentan las **hojas (páginas) que se imprimen** y se
+  asignan tantos números consecutivos como hojas, separados por coma y sin datos
+  de CAI.
 * Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
   CAI (ya vienen en el papel).
 
@@ -60,8 +55,8 @@ En *Inventario > Configuración > Tipos de operación*, para un tipo de operaci�
 de salida:
 
 #. Definir el *Tipo de documento* de remito.
-#. Destildar *Autoimpreso* (así el tipo pasa a preimpreso).
-#. Opcionalmente cargar *Renglones por Remito*.
+#. Dejar el *CAI* vacío (así el casillero *Autoimpreso* queda destildado y el
+   tipo pasa a preimpreso).
 
 Credits
 =======

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -1,0 +1,66 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================
+Remito Preimpreso para Argentina
+===============================
+
+Reincorpora el soporte de **remitos preimpresos de imprenta** sobre el flujo de
+remitos argentinos de ``l10n_ar_stock`` / ``l10n_ar_stock_ux``.
+
+Un remito preimpreso es papel provisto por una imprenta que ya trae impresos el
+encabezado, la numeración y el CAI. En ese caso Odoo solo imprime el contenido
+variable (productos, cliente) y numera las transferencias según los comprobantes
+(hojas) que consume.
+
+Cómo se distingue del autoimpreso
+=================================
+
+El modo se **deriva del tipo de operación**, sin campos nuevos que el usuario
+deba marcar:
+
+* **Autoimpreso** — el tipo de operación tiene CAI cargado. Se imprime el
+  comprobante completo (encabezado, número y CAI) y se numera con un único
+  número por transferencia (comportamiento estándar de ``l10n_ar_stock``).
+* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
+  configurado pero **no** tiene CAI (el CAI viene impreso en el papel). Este
+  módulo habilita ese caso relajando la obligatoriedad del CAI.
+
+Qué agrega
+==========
+
+* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): indica si el tipo de
+  operación es preimpreso (tiene documento de remito y no tiene CAI).
+* ``stock.picking.type.l10n_ar_lines_per_voucher``: renglones que entran en cada
+  hoja preimpresa. Se usa para calcular cuántos números consume una entrega
+  larga. Si es 0, cada entrega consume un único número.
+* Numeración: al generar la guía de remito en un tipo preimpreso, se asignan
+  tantos números consecutivos como hojas consuma la entrega
+  (``ceil(renglones / renglones_por_hoja)``), separados por coma, sin datos de
+  CAI.
+* Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
+  CAI (ya vienen en el papel).
+
+Configuración
+=============
+
+En *Inventario > Configuración > Tipos de operación*, para un tipo de operación
+de salida:
+
+#. Definir el *Tipo de documento* de remito.
+#. Dejar el *CAI* vacío (así el tipo pasa a preimpreso).
+#. Opcionalmente cargar *Renglones por Remito*.
+
+Credits
+=======
+
+|company| |company_logo|

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -25,21 +25,24 @@ variable (productos, cliente) y numera las transferencias según los comprobante
 Cómo se distingue del autoimpreso
 =================================
 
-El modo se **deriva del tipo de operación**, sin campos nuevos que el usuario
-deba marcar:
+Un casillero **Autoimpreso** en el tipo de operación define el modo:
 
-* **Autoimpreso** — el tipo de operación tiene CAI cargado. Se imprime el
-  comprobante completo (encabezado, número y CAI) y se numera con un único
-  número por transferencia (comportamiento estándar de ``l10n_ar_stock``).
-* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
-  configurado pero **no** tiene CAI (el CAI viene impreso en el papel). Este
-  módulo habilita ese caso relajando la obligatoriedad del CAI.
+* **Autoimpreso** (tildado) — Odoo imprime el comprobante completo (encabezado,
+  número y CAI); el CAI es obligatorio. Se numera con un único número por
+  transferencia (comportamiento estándar de ``l10n_ar_stock``).
+* **Preimpreso** (destildado) — el papel de imprenta ya trae encabezado,
+  numeración y CAI. No se pide CAI y Odoo solo imprime el contenido variable,
+  numerando según las hojas consumidas.
 
 Qué agrega
 ==========
 
-* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): indica si el tipo de
-  operación es preimpreso (tiene documento de remito y no tiene CAI).
+* ``stock.picking.type.l10n_ar_autoprinted``: casillero *Autoimpreso* (por
+  defecto verdadero). Al destildarlo, el CAI deja de pedirse y aparecen los
+  *Renglones por Remito*.
+* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): verdadero cuando hay
+  documento de remito y el tipo **no** es autoimpreso. Lo usan el reporte y la
+  numeración.
 * ``stock.picking.type.l10n_ar_lines_per_voucher``: renglones que entran en cada
   hoja preimpresa. Se usa para calcular cuántos números consume una entrega
   larga. Si es 0, cada entrega consume un único número.
@@ -57,7 +60,7 @@ En *Inventario > Configuración > Tipos de operación*, para un tipo de operaci�
 de salida:
 
 #. Definir el *Tipo de documento* de remito.
-#. Dejar el *CAI* vacío (así el tipo pasa a preimpreso).
+#. Destildar *Autoimpreso* (así el tipo pasa a preimpreso).
 #. Opcionalmente cargar *Renglones por Remito*.
 
 Credits

--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -25,26 +25,29 @@ se imprimen.
 Cómo se distingue del autoimpreso
 =================================
 
-El modo se **autocalcula según el CAI** del tipo de operación:
+El modo es una **decisión explícita** del tipo de operación, en el campo
+*Modo de Impresión del Remito*:
 
-* **Autoimpreso** — el tipo de operación tiene CAI cargado. Odoo imprime el
-  comprobante completo (encabezado, número y CAI) y numera con un único número
-  por transferencia (comportamiento estándar de ``l10n_ar_stock``).
-* **Preimpreso** — el tipo de operación tiene un tipo de documento de remito
-  pero **no** tiene CAI. Este módulo habilita ese caso relajando la
-  obligatoriedad del CAI.
+* **Autoimpreso** (default) — Odoo imprime el comprobante completo (encabezado,
+  número y CAI) y numera con un único número por transferencia (comportamiento
+  estándar de ``l10n_ar_stock``). El CAI, su vencimiento y el rango autorizado
+  son obligatorios porque Odoo los imprime.
+* **Preimpreso** — el papel de imprenta ya trae encabezado, numeración y CAI.
+  Odoo solo imprime el contenido variable y numera según las hojas que se
+  consumen. El CAI, su vencimiento y el rango se ocultan y dejan de pedirse.
 
 Qué agrega
 ==========
 
-* ``stock.picking.type.l10n_ar_autoprinted`` (computado): casillero *Autoimpreso*
-  de solo lectura; verdadero cuando hay CAI cargado.
-* ``stock.picking.type.l10n_ar_is_preprinted`` (computado): verdadero cuando hay
-  documento de remito y no hay CAI. Lo usan el reporte y la numeración.
+* ``stock.picking.type.l10n_ar_voucher_print_mode`` (selección, almacenada):
+  *Autoimpreso* / *Preimpreso*. Lo usan la vista, el reporte y la numeración.
+  Una restricción de servidor exige CAI, vencimiento y rango cuando el modo es
+  autoimpreso (la vista sola no cubre imports ni escrituras por ORM).
 * Numeración: al generar la guía de remito en un tipo preimpreso, se renderiza el
   comprobante de entrega, se cuentan las **hojas (páginas) que se imprimen** y se
   asignan tantos números consecutivos como hojas, separados por coma y sin datos
-  de CAI.
+  de CAI. Si el reporte está configurado con duplicado/triplicado, el juego de
+  copias consume un solo número por hoja.
 * Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
   CAI (ya vienen en el papel).
 
@@ -55,8 +58,10 @@ En *Inventario > Configuración > Tipos de operación*, para un tipo de operaci�
 de salida:
 
 #. Definir el *Tipo de documento* de remito.
-#. Dejar el *CAI* vacío (así el casillero *Autoimpreso* queda destildado y el
-   tipo pasa a preimpreso).
+#. Poner *Modo de Impresión del Remito* en **Preimpreso**.
+#. Ajustar el *Prefijo* (punto de venta) y el *Próximo número* para que coincidan
+   con la primera hoja del talonario de la imprenta. Estos dos campos se piden en
+   los dos modos.
 
 Credits
 =======

--- a/l10n_ar_stock_preprinted/__init__.py
+++ b/l10n_ar_stock_preprinted/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_stock_preprinted/__manifest__.py
+++ b/l10n_ar_stock_preprinted/__manifest__.py
@@ -1,0 +1,19 @@
+{
+    "name": "Remito Preimpreso para Argentina",
+    "version": "19.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Soporte de remitos preimpresos de imprenta (con CAI y numeración en el papel)",
+    "depends": [
+        "l10n_ar_stock_ux",
+    ],
+    "data": [
+        "views/stock_picking_type_views.xml",
+        "views/report_deliveryslip.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/l10n_ar_stock_preprinted/models/__init__.py
+++ b/l10n_ar_stock_preprinted/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking_type
+from . import stock_picking

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,0 +1,45 @@
+import math
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    l10n_ar_is_preprinted = fields.Boolean(
+        related="picking_type_id.l10n_ar_is_preprinted",
+    )
+
+    def _l10n_ar_get_voucher_count(self):
+        """Cantidad de comprobantes preimpresos (hojas) que consume la entrega.
+
+        Cada hoja preimpresa trae su propio número; una entrega con más renglones de los que
+        entran en una hoja consume varios números. Se calcula como el techo de
+        (renglones a imprimir / renglones por hoja del tipo de operación). Si no se configuró
+        ``l10n_ar_lines_per_voucher``, la entrega consume un único número.
+        """
+        self.ensure_one()
+        lines_per_voucher = self.picking_type_id.l10n_ar_lines_per_voucher
+        line_count = len(self.move_ids.filtered(lambda m: m.product_uom_qty))
+        if not lines_per_voucher or not line_count:
+            return 1
+        return math.ceil(line_count / lines_per_voucher)
+
+    def l10n_ar_action_create_delivery_guide(self):
+        """En remitos preimpresos numeramos según las hojas consumidas (varios números
+        separados por coma) y sin datos de CAI (el CAI viene impreso en el papel). En
+        autoimpresos se delega al flujo estándar de Odoo (un número + datos de CAI)."""
+        self.ensure_one()
+        if self.l10n_ar_is_preprinted:
+            if not self.l10n_ar_delivery_guide_number:
+                picking_type = self.picking_type_id
+                picking_type._ensure_l10n_ar_stock_sequence()
+                count = self._l10n_ar_get_voucher_count()
+                numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(count)]
+                self.l10n_ar_delivery_guide_number = ",".join(numbers)
+                # guardamos solo el tipo de documento; el CAI no aplica (viene preimpreso)
+                self.l10n_ar_cai_data = {
+                    "document_type_id": picking_type.l10n_ar_document_type_id.id,
+                }
+            return
+        return super().l10n_ar_action_create_delivery_guide()

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -7,8 +7,8 @@ from odoo import fields, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    l10n_ar_is_preprinted = fields.Boolean(
-        related="picking_type_id.l10n_ar_is_preprinted",
+    l10n_ar_voucher_print_mode = fields.Selection(
+        related="picking_type_id.l10n_ar_voucher_print_mode",
     )
 
     def _l10n_ar_count_pages_with_products(self, pdf_reader):
@@ -70,7 +70,7 @@ class StockPicking(models.Model):
         dispara impresiones automáticas. En autoimpresos se delega al flujo estándar de
         Odoo (un número + datos de CAI)."""
         self.ensure_one()
-        if self.l10n_ar_is_preprinted:
+        if self.l10n_ar_voucher_print_mode == "preprinted":
             if not self.l10n_ar_delivery_guide_number:
                 picking_type = self.picking_type_id
                 picking_type._ensure_l10n_ar_stock_sequence()

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,4 +1,3 @@
-import re
 from io import BytesIO
 
 from odoo import fields, models
@@ -8,6 +7,12 @@ from odoo.tools.pdf import PdfReader
 # cada copia repite TODAS las páginas del comprobante
 COPIES_BY_L10N_AR_COPIES = {"duplicado": 2, "triplicado": 3}
 
+# marca invisible (texto blanco de 1px) que el comprobante imprime una vez por línea de
+# producto cuando se renderiza para contar hojas (contexto l10n_ar_counting). Permite saber
+# qué páginas tienen productos sin depender de que el producto tenga código ni de heurísticas
+# de texto: una hoja de solo transportista / firma / totales no la lleva y no consume número.
+L10N_AR_PREPRINTED_LINE_MARK = "PREPRINTEDLINEMARK"
+
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
@@ -16,38 +21,34 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_voucher_print_mode",
     )
 
-    def _l10n_ar_count_pages_with_products(self, pdf_reader):
-        """Cuenta las páginas del PDF que realmente contienen líneas de producto,
-        analizando el texto de cada hoja: una hoja que solo trae firma o totales NO
-        consume número de remito. La detección usa los identificadores del producto
-        (código interno / código de barras) para ser independiente del idioma; si el
-        producto no tiene código, cae a un patrón numérico genérico (cantidad/precio
-        con decimales)."""
+    def _get_name_delivery_report(self, report_xml_id):
+        """Los tipos preimpresos usan SIEMPRE el comprobante argentino, tengan o no número de
+        remito asignado. El core de ``l10n_ar_stock_ux`` solo lo elige cuando ya hay número,
+        pero lo necesitamos también antes: sin número el picking se imprime como comprobante
+        de entrega normal (no el remito de Odoo), y durante el conteo de hojas se fuerza el
+        layout preimpreso — los dos casos requieren el template argentino."""
         self.ensure_one()
-        move_lines = self.move_line_ids or self.move_ids
-        identifiers = set()
-        for line in move_lines:
-            product = line.product_id
-            if product.default_code:
-                identifiers.add(product.default_code.lower().strip())
-            if product.barcode:
-                identifiers.add(product.barcode.lower().strip())
+        if self.company_id.country_id.code == "AR" and self.l10n_ar_voucher_print_mode == "preprinted":
+            return "l10n_ar_stock_ux.report_delivery_document"
+        return super()._get_name_delivery_report(report_xml_id)
 
+    def _l10n_ar_count_pages_with_products(self, pdf_reader):
+        """Cuenta las páginas del PDF que contienen líneas de producto: una hoja que solo
+        trae firma, totales o datos del transportista NO consume número de remito. El
+        comprobante imprime una marca invisible (``L10N_AR_PREPRINTED_LINE_MARK``) por cada
+        línea de producto cuando se renderiza con el contexto de conteo, así que una página
+        con productos trae al menos una marca. Es independiente del idioma y de que el
+        producto tenga código interno o de barras."""
+        self.ensure_one()
         pages_with_products = 0
         for page in pdf_reader.pages:
             try:
-                text = (page.extract_text() or "").lower()
+                text = page.extract_text() or ""
             except Exception:
                 # Si no se puede extraer el texto, asumimos que la hoja trae productos.
                 pages_with_products += 1
                 continue
-            if not text:
-                continue
-            if identifiers:
-                has_products = any(identifier in text for identifier in identifiers)
-            else:
-                has_products = bool(re.search(r"\b\d+[.,]\d+\b", text))
-            if has_products:
+            if L10N_AR_PREPRINTED_LINE_MARK in text:
                 pages_with_products += 1
         return max(1, pages_with_products)
 
@@ -63,9 +64,15 @@ class StockPicking(models.Model):
         reporte (original / duplicado / triplicado), y el juego de copias consume UN solo
         número, así que acotamos el conteo a las páginas de una sola copia."""
         self.ensure_one()
-        # sin sudo: el conteo lo dispara el usuario que genera la guía, con los mismos permisos
-        # que tiene al imprimir el remito a mano
         report = self.env.ref("stock.action_report_delivery")
+        # Renderizamos con sudo y con el contexto l10n_ar_counting:
+        # - sudo: el motor de reportes corre elevado cuando imprimís a mano; llamándolo
+        #   directo como usuario, el comprobante toca modelos relacionados (p.ej. el tipo de
+        #   pedido de venta) que el operador no puede leer y falla por permisos.
+        # - l10n_ar_counting: el conteo corre ANTES de asignar el número, así que sin el flag
+        #   el comprobante saldría como "Comprobante de Entrega" y paginaría distinto a lo que
+        #   después se imprime; el flag fuerza el layout preimpreso e imprime la marca de línea.
+        report = report.sudo().with_context(l10n_ar_counting=True)
         pdf_content, _dummy = report._render_qweb_pdf(report.id, self.ids)
         pdf_reader = PdfReader(BytesIO(pdf_content))
         copies = COPIES_BY_L10N_AR_COPIES.get(report.l10n_ar_copies, 1)

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -2,6 +2,11 @@ import re
 from io import BytesIO
 
 from odoo import fields, models
+from odoo.tools.pdf import PdfReader
+
+# copias que agrega el reporte según ir.actions.report.l10n_ar_copies (l10n_ar_ux):
+# cada copia repite TODAS las páginas del comprobante
+COPIES_BY_L10N_AR_COPIES = {"duplicado": 2, "triplicado": 3}
 
 
 class StockPicking(models.Model):
@@ -10,6 +15,16 @@ class StockPicking(models.Model):
     l10n_ar_voucher_print_mode = fields.Selection(
         related="picking_type_id.l10n_ar_voucher_print_mode",
     )
+
+    def _get_name_delivery_report(self, report_xml_id):
+        """Al contar las hojas del preimpreso el número de remito todavía no está asignado, y
+        ``l10n_ar_stock_ux`` elige el template argentino justamente por tener número. Sin esto
+        contaríamos las hojas del comprobante estándar de Odoo, que pagina distinto al que se
+        imprime."""
+        self.ensure_one()
+        if self.env.context.get("l10n_ar_preprinted_sheet_count") and self.company_id.country_id.code == "AR":
+            return "l10n_ar_stock_ux.report_delivery_document"
+        return super()._get_name_delivery_report(report_xml_id)
 
     def _l10n_ar_count_pages_with_products(self, pdf_reader):
         """Cuenta las páginas del PDF que realmente contienen líneas de producto,
@@ -50,15 +65,21 @@ class StockPicking(models.Model):
         """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
         realmente se imprimen con productos (las hojas de solo firma/totales no consumen
         número). Se obtiene renderizando el comprobante de entrega y contando esas páginas
-        del PDF resultante."""
+        del PDF resultante.
+
+        El PDF trae el comprobante repetido tantas veces como copias tenga configurado el
+        reporte (original / duplicado / triplicado), y el juego de copias consume UN solo
+        número, así que acotamos el conteo a las páginas de una sola copia."""
         self.ensure_one()
-        try:
-            from PyPDF2 import PdfReader
-        except ImportError:
-            from pypdf import PdfReader
-        report = self.env.ref("stock.action_report_delivery")
-        pdf_content, _dummy = report.sudo()._render_qweb_pdf(report.id, self.ids)
-        return self._l10n_ar_count_pages_with_products(PdfReader(BytesIO(pdf_content)))
+        report = self.env.ref("stock.action_report_delivery").sudo()
+        pdf_content, _dummy = report.with_context(l10n_ar_preprinted_sheet_count=True)._render_qweb_pdf(
+            report.id, self.ids
+        )
+        pdf_reader = PdfReader(BytesIO(pdf_content))
+        copies = COPIES_BY_L10N_AR_COPIES.get(report.l10n_ar_copies, 1)
+        pages_per_copy = len(pdf_reader.pages) // copies
+        sheets = self._l10n_ar_count_pages_with_products(pdf_reader)
+        return max(1, min(sheets, pages_per_copy))
 
     def l10n_ar_action_create_delivery_guide(self):
         """En remitos preimpresos numeramos según las hojas realmente impresas (una por

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,3 +1,4 @@
+import re
 from io import BytesIO
 
 from odoo import fields, models
@@ -10,10 +11,46 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_is_preprinted",
     )
 
+    def _l10n_ar_count_pages_with_products(self, pdf_reader):
+        """Cuenta las páginas del PDF que realmente contienen líneas de producto,
+        analizando el texto de cada hoja: una hoja que solo trae firma o totales NO
+        consume número de remito. La detección usa los identificadores del producto
+        (código interno / código de barras) para ser independiente del idioma; si el
+        producto no tiene código, cae a un patrón numérico genérico (cantidad/precio
+        con decimales)."""
+        self.ensure_one()
+        move_lines = self.move_line_ids or self.move_ids
+        identifiers = set()
+        for line in move_lines:
+            product = line.product_id
+            if product.default_code:
+                identifiers.add(product.default_code.lower().strip())
+            if product.barcode:
+                identifiers.add(product.barcode.lower().strip())
+
+        pages_with_products = 0
+        for page in pdf_reader.pages:
+            try:
+                text = (page.extract_text() or "").lower()
+            except Exception:
+                # Si no se puede extraer el texto, asumimos que la hoja trae productos.
+                pages_with_products += 1
+                continue
+            if not text:
+                continue
+            if identifiers:
+                has_products = any(identifier in text for identifier in identifiers)
+            else:
+                has_products = bool(re.search(r"\b\d+[.,]\d+\b", text))
+            if has_products:
+                pages_with_products += 1
+        return max(1, pages_with_products)
+
     def _l10n_ar_count_preprinted_sheets(self):
         """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
-        realmente se imprimen con productos. Se obtiene renderizando el comprobante de
-        entrega y contando las páginas del PDF resultante."""
+        realmente se imprimen con productos (las hojas de solo firma/totales no consumen
+        número). Se obtiene renderizando el comprobante de entrega y contando esas páginas
+        del PDF resultante."""
         self.ensure_one()
         try:
             from PyPDF2 import PdfReader
@@ -21,13 +58,17 @@ class StockPicking(models.Model):
             from pypdf import PdfReader
         report = self.env.ref("stock.action_report_delivery")
         pdf_content, _dummy = report.sudo()._render_qweb_pdf(report.id, self.ids)
-        return max(1, len(PdfReader(BytesIO(pdf_content)).pages))
+        return self._l10n_ar_count_pages_with_products(PdfReader(BytesIO(pdf_content)))
 
     def l10n_ar_action_create_delivery_guide(self):
         """En remitos preimpresos numeramos según las hojas realmente impresas (una por
         página del comprobante), con varios números separados por coma y sin datos de CAI
-        (el CAI viene preimpreso en el papel). En autoimpresos se delega al flujo estándar
-        de Odoo (un número + datos de CAI)."""
+        (el CAI viene preimpreso en el papel), y devolvemos la acción de impresión: el
+        botón numera e imprime en un solo paso. Los números NO se imprimen en el PDF (el
+        papel de imprenta ya los trae); solo se registran en el picking. Cuando el método
+        corre desde ``_action_done`` (autoasignación) el retorno se ignora, así que no
+        dispara impresiones automáticas. En autoimpresos se delega al flujo estándar de
+        Odoo (un número + datos de CAI)."""
         self.ensure_one()
         if self.l10n_ar_is_preprinted:
             if not self.l10n_ar_delivery_guide_number:
@@ -40,5 +81,5 @@ class StockPicking(models.Model):
                 self.l10n_ar_cai_data = {
                     "document_type_id": picking_type.l10n_ar_document_type_id.id,
                 }
-            return
+            return self.env.ref("stock.action_report_delivery").report_action(self)
         return super().l10n_ar_action_create_delivery_guide()

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -16,16 +16,6 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_voucher_print_mode",
     )
 
-    def _get_name_delivery_report(self, report_xml_id):
-        """Al contar las hojas del preimpreso el número de remito todavía no está asignado, y
-        ``l10n_ar_stock_ux`` elige el template argentino justamente por tener número. Sin esto
-        contaríamos las hojas del comprobante estándar de Odoo, que pagina distinto al que se
-        imprime."""
-        self.ensure_one()
-        if self.env.context.get("l10n_ar_preprinted_sheet_count") and self.company_id.country_id.code == "AR":
-            return "l10n_ar_stock_ux.report_delivery_document"
-        return super()._get_name_delivery_report(report_xml_id)
-
     def _l10n_ar_count_pages_with_products(self, pdf_reader):
         """Cuenta las páginas del PDF que realmente contienen líneas de producto,
         analizando el texto de cada hoja: una hoja que solo trae firma o totales NO
@@ -65,7 +55,9 @@ class StockPicking(models.Model):
         """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
         realmente se imprimen con productos (las hojas de solo firma/totales no consumen
         número). Se obtiene renderizando el comprobante de entrega y contando esas páginas
-        del PDF resultante.
+        del PDF resultante. El render es el mismo comprobante argentino que se imprime
+        (``l10n_ar_stock_ux`` lo elige para toda transferencia de compañía AR), así que la
+        paginación que contamos es la que sale en papel.
 
         El PDF trae el comprobante repetido tantas veces como copias tenga configurado el
         reporte (original / duplicado / triplicado), y el juego de copias consume UN solo
@@ -74,9 +66,7 @@ class StockPicking(models.Model):
         # sin sudo: el conteo lo dispara el usuario que genera la guía, con los mismos permisos
         # que tiene al imprimir el remito a mano
         report = self.env.ref("stock.action_report_delivery")
-        pdf_content, _dummy = report.with_context(l10n_ar_preprinted_sheet_count=True)._render_qweb_pdf(
-            report.id, self.ids
-        )
+        pdf_content, _dummy = report._render_qweb_pdf(report.id, self.ids)
         pdf_reader = PdfReader(BytesIO(pdf_content))
         copies = COPIES_BY_L10N_AR_COPIES.get(report.l10n_ar_copies, 1)
         pages_per_copy = len(pdf_reader.pages) // copies

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -1,4 +1,4 @@
-import math
+from io import BytesIO
 
 from odoo import fields, models
 
@@ -10,34 +10,33 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_is_preprinted",
     )
 
-    def _l10n_ar_get_voucher_count(self):
-        """Cantidad de comprobantes preimpresos (hojas) que consume la entrega.
-
-        Cada hoja preimpresa trae su propio número; una entrega con más renglones de los que
-        entran en una hoja consume varios números. Se calcula como el techo de
-        (renglones a imprimir / renglones por hoja del tipo de operación). Si no se configuró
-        ``l10n_ar_lines_per_voucher``, la entrega consume un único número.
-        """
+    def _l10n_ar_count_preprinted_sheets(self):
+        """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
+        realmente se imprimen con productos. Se obtiene renderizando el comprobante de
+        entrega y contando las páginas del PDF resultante."""
         self.ensure_one()
-        lines_per_voucher = self.picking_type_id.l10n_ar_lines_per_voucher
-        line_count = len(self.move_ids.filtered(lambda m: m.product_uom_qty))
-        if not lines_per_voucher or not line_count:
-            return 1
-        return math.ceil(line_count / lines_per_voucher)
+        try:
+            from PyPDF2 import PdfReader
+        except ImportError:
+            from pypdf import PdfReader
+        report = self.env.ref("stock.action_report_delivery")
+        pdf_content, _dummy = report.sudo()._render_qweb_pdf(report.id, self.ids)
+        return max(1, len(PdfReader(BytesIO(pdf_content)).pages))
 
     def l10n_ar_action_create_delivery_guide(self):
-        """En remitos preimpresos numeramos según las hojas consumidas (varios números
-        separados por coma) y sin datos de CAI (el CAI viene impreso en el papel). En
-        autoimpresos se delega al flujo estándar de Odoo (un número + datos de CAI)."""
+        """En remitos preimpresos numeramos según las hojas realmente impresas (una por
+        página del comprobante), con varios números separados por coma y sin datos de CAI
+        (el CAI viene preimpreso en el papel). En autoimpresos se delega al flujo estándar
+        de Odoo (un número + datos de CAI)."""
         self.ensure_one()
         if self.l10n_ar_is_preprinted:
             if not self.l10n_ar_delivery_guide_number:
                 picking_type = self.picking_type_id
                 picking_type._ensure_l10n_ar_stock_sequence()
-                count = self._l10n_ar_get_voucher_count()
-                numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(count)]
+                sheets = self._l10n_ar_count_preprinted_sheets()
+                numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(sheets)]
                 self.l10n_ar_delivery_guide_number = ",".join(numbers)
-                # guardamos solo el tipo de documento; el CAI no aplica (viene preimpreso)
+                # el CAI no aplica al preimpreso (viene impreso en el papel)
                 self.l10n_ar_cai_data = {
                     "document_type_id": picking_type.l10n_ar_document_type_id.id,
                 }

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -71,7 +71,9 @@ class StockPicking(models.Model):
         reporte (original / duplicado / triplicado), y el juego de copias consume UN solo
         número, así que acotamos el conteo a las páginas de una sola copia."""
         self.ensure_one()
-        report = self.env.ref("stock.action_report_delivery").sudo()
+        # sin sudo: el conteo lo dispara el usuario que genera la guía, con los mismos permisos
+        # que tiene al imprimir el remito a mano
+        report = self.env.ref("stock.action_report_delivery")
         pdf_content, _dummy = report.with_context(l10n_ar_preprinted_sheet_count=True)._render_qweb_pdf(
             report.id, self.ids
         )

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -1,26 +1,60 @@
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
-    l10n_ar_autoprinted = fields.Boolean(
-        string="Autoimpreso",
-        default=True,
-        help="Argentina: cuando está activo el remito es autoimpreso (Odoo imprime el comprobante "
-        "completo: encabezado, número y CAI, y el CAI con su vencimiento son obligatorios). Cuando se "
-        "desactiva el remito es preimpreso: el papel de imprenta ya trae encabezado, numeración y CAI, "
-        "por lo que el CAI deja de pedirse y Odoo solo imprime el contenido variable numerando según "
-        "las hojas que se consumen.",
-    )
-    l10n_ar_is_preprinted = fields.Boolean(
-        string="Remito Preimpreso",
-        compute="_compute_l10n_ar_is_preprinted",
-        help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
-        "configurado y NO es autoimpreso (es preimpreso). Lo usan el reporte y la numeración.",
+    l10n_ar_voucher_print_mode = fields.Selection(
+        selection=[
+            ("autoprinted", "Autoimpreso"),
+            ("preprinted", "Preimpreso"),
+        ],
+        string="Modo de Impresión del Remito",
+        default="autoprinted",
+        help="Argentina: cómo se imprime el remito de este tipo de operación.\n"
+        "* Autoimpreso: Odoo imprime el comprobante completo (encabezado, número y CAI), por lo que "
+        "el CAI, su vencimiento y el rango autorizado son obligatorios.\n"
+        "* Preimpreso: el papel de imprenta ya trae encabezado, numeración y CAI, así que Odoo solo "
+        "imprime el contenido variable y numera según las hojas que se consumen. El CAI no se carga "
+        "acá porque viene impreso en el papel.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
-    def _compute_l10n_ar_is_preprinted(self):
-        for rec in self:
-            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains(
+        "l10n_ar_voucher_print_mode",
+        "l10n_ar_document_type_id",
+        "l10n_ar_cai_authorization_code",
+        "l10n_ar_cai_expiration_date",
+        "l10n_ar_sequence_number_start",
+        "l10n_ar_sequence_number_end",
+    )
+    def _constrains_l10n_ar_voucher_print_mode(self):
+        """El CAI y su rango son obligatorios en autoimpreso porque Odoo los imprime. La vista ya los
+        pide, pero el modo también puede setearse por import / data / ORM, donde el required de la
+        vista no aplica."""
+        for picking_type in self.filtered(
+            lambda x: x.l10n_ar_document_type_id and x.l10n_ar_voucher_print_mode == "autoprinted"
+        ):
+            missing = [
+                name
+                for name, value in (
+                    (_("CAI"), picking_type.l10n_ar_cai_authorization_code),
+                    (_("CAI Expiration Date"), picking_type.l10n_ar_cai_expiration_date),
+                    (_("Sequence From"), picking_type.l10n_ar_sequence_number_start),
+                    (_("Sequence To"), picking_type.l10n_ar_sequence_number_end),
+                )
+                if not value
+            ]
+            if missing:
+                raise ValidationError(
+                    _(
+                        "En el tipo de operación %(picking_type)s el remito es autoimpreso, así que"
+                        " debe completar: %(fields)s.\nSi el papel lo provee una imprenta (ya trae"
+                        " encabezado, numeración y CAI), configure el Modo de Impresión del Remito"
+                        " como Preimpreso.",
+                        picking_type=picking_type.display_name,
+                        fields=", ".join(missing),
+                    )
+                )

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -6,23 +6,21 @@ class StockPickingType(models.Model):
 
     l10n_ar_autoprinted = fields.Boolean(
         string="Autoimpreso",
-        compute="_compute_l10n_ar_preprinted_flags",
-        help="Argentina: se autocalcula según el CAI. Con CAI cargado el remito es autoimpreso "
-        "(Odoo imprime el comprobante completo: encabezado, número y CAI). Sin CAI es preimpreso "
-        "(el papel de imprenta ya trae encabezado, numeración y CAI; Odoo solo imprime el contenido "
-        "variable y numera según las hojas que se imprimen).",
+        default=True,
+        help="Argentina: cuando está activo el remito es autoimpreso (Odoo imprime el comprobante "
+        "completo: encabezado, número y CAI, y el CAI con su vencimiento son obligatorios). Cuando se "
+        "desactiva el remito es preimpreso: el papel de imprenta ya trae encabezado, numeración y CAI, "
+        "por lo que el CAI deja de pedirse y Odoo solo imprime el contenido variable numerando según "
+        "las hojas que se consumen.",
     )
     l10n_ar_is_preprinted = fields.Boolean(
         string="Remito Preimpreso",
-        compute="_compute_l10n_ar_preprinted_flags",
+        compute="_compute_l10n_ar_is_preprinted",
         help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
-        "configurado y NO tiene CAI (es preimpreso). Lo usan el reporte y la numeración.",
+        "configurado y NO es autoimpreso (es preimpreso). Lo usan el reporte y la numeración.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
-    def _compute_l10n_ar_preprinted_flags(self):
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
+    def _compute_l10n_ar_is_preprinted(self):
         for rec in self:
-            has_doc_type = bool(rec.l10n_ar_document_type_id)
-            has_cai = bool(rec.l10n_ar_cai_authorization_code)
-            rec.l10n_ar_autoprinted = has_doc_type and has_cai
-            rec.l10n_ar_is_preprinted = has_doc_type and not has_cai
+            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -4,14 +4,19 @@ from odoo import api, fields, models
 class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
+    l10n_ar_autoprinted = fields.Boolean(
+        string="Autoimpreso",
+        default=True,
+        help="Argentina: si está tildado, el remito es autoimpreso: Odoo imprime el comprobante "
+        "completo (encabezado, número y CAI) y por eso el CAI es obligatorio. Si se destilda, el "
+        "remito es preimpreso (el papel de imprenta ya trae encabezado, numeración y CAI): no se "
+        "pide CAI y Odoo solo imprime el contenido variable, numerando según las hojas consumidas.",
+    )
     l10n_ar_is_preprinted = fields.Boolean(
         string="Remito Preimpreso",
         compute="_compute_l10n_ar_is_preprinted",
-        help="Argentina: se considera 'preimpreso' cuando el tipo de operación tiene un tipo de "
-        "documento de remito configurado pero NO tiene CAI cargado. En ese caso el papel del remito "
-        "viene preimpreso de imprenta, ya con su numeración y CAI; Odoo solo imprime el contenido "
-        "variable (sin encabezado, sin CAI y sin número). Si el CAI está cargado se trata de un "
-        "remito autoimpreso y se imprime el comprobante completo.",
+        help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
+        "configurado y NO es autoimpreso. Lo usa el reporte y la numeración.",
     )
     l10n_ar_lines_per_voucher = fields.Integer(
         string="Renglones por Remito",
@@ -21,7 +26,7 @@ class StockPickingType(models.Model):
         "único número.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
     def _compute_l10n_ar_is_preprinted(self):
         for rec in self:
-            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_cai_authorization_code
+            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -6,27 +6,23 @@ class StockPickingType(models.Model):
 
     l10n_ar_autoprinted = fields.Boolean(
         string="Autoimpreso",
-        default=True,
-        help="Argentina: si está tildado, el remito es autoimpreso: Odoo imprime el comprobante "
-        "completo (encabezado, número y CAI) y por eso el CAI es obligatorio. Si se destilda, el "
-        "remito es preimpreso (el papel de imprenta ya trae encabezado, numeración y CAI): no se "
-        "pide CAI y Odoo solo imprime el contenido variable, numerando según las hojas consumidas.",
+        compute="_compute_l10n_ar_preprinted_flags",
+        help="Argentina: se autocalcula según el CAI. Con CAI cargado el remito es autoimpreso "
+        "(Odoo imprime el comprobante completo: encabezado, número y CAI). Sin CAI es preimpreso "
+        "(el papel de imprenta ya trae encabezado, numeración y CAI; Odoo solo imprime el contenido "
+        "variable y numera según las hojas que se imprimen).",
     )
     l10n_ar_is_preprinted = fields.Boolean(
         string="Remito Preimpreso",
-        compute="_compute_l10n_ar_is_preprinted",
+        compute="_compute_l10n_ar_preprinted_flags",
         help="Argentina: verdadero cuando el tipo de operación tiene un tipo de documento de remito "
-        "configurado y NO es autoimpreso. Lo usa el reporte y la numeración.",
-    )
-    l10n_ar_lines_per_voucher = fields.Integer(
-        string="Renglones por Remito",
-        help="Argentina (preimpreso): cantidad de renglones que entran en cada hoja/comprobante "
-        "preimpreso. Se usa para calcular cuántos números de remito consume una entrega larga "
-        "(cada hoja preimpresa tiene su propio número). Si se deja en 0, cada entrega consume un "
-        "único número.",
+        "configurado y NO tiene CAI (es preimpreso). Lo usan el reporte y la numeración.",
     )
 
-    @api.depends("l10n_ar_document_type_id", "l10n_ar_autoprinted")
-    def _compute_l10n_ar_is_preprinted(self):
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
+    def _compute_l10n_ar_preprinted_flags(self):
         for rec in self:
-            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_autoprinted
+            has_doc_type = bool(rec.l10n_ar_document_type_id)
+            has_cai = bool(rec.l10n_ar_cai_authorization_code)
+            rec.l10n_ar_autoprinted = has_doc_type and has_cai
+            rec.l10n_ar_is_preprinted = has_doc_type and not has_cai

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -1,0 +1,27 @@
+from odoo import api, fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    l10n_ar_is_preprinted = fields.Boolean(
+        string="Remito Preimpreso",
+        compute="_compute_l10n_ar_is_preprinted",
+        help="Argentina: se considera 'preimpreso' cuando el tipo de operación tiene un tipo de "
+        "documento de remito configurado pero NO tiene CAI cargado. En ese caso el papel del remito "
+        "viene preimpreso de imprenta, ya con su numeración y CAI; Odoo solo imprime el contenido "
+        "variable (sin encabezado, sin CAI y sin número). Si el CAI está cargado se trata de un "
+        "remito autoimpreso y se imprime el comprobante completo.",
+    )
+    l10n_ar_lines_per_voucher = fields.Integer(
+        string="Renglones por Remito",
+        help="Argentina (preimpreso): cantidad de renglones que entran en cada hoja/comprobante "
+        "preimpreso. Se usa para calcular cuántos números de remito consume una entrega larga "
+        "(cada hoja preimpresa tiene su propio número). Si se deja en 0, cada entrega consume un "
+        "único número.",
+    )
+
+    @api.depends("l10n_ar_document_type_id", "l10n_ar_cai_authorization_code")
+    def _compute_l10n_ar_is_preprinted(self):
+        for rec in self:
+            rec.l10n_ar_is_preprinted = bool(rec.l10n_ar_document_type_id) and not rec.l10n_ar_cai_authorization_code

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -12,6 +12,7 @@ class StockPickingType(models.Model):
         ],
         string="Modo de Impresión del Remito",
         default="autoprinted",
+        required=True,
         help="Argentina: cómo se imprime el remito de este tipo de operación.\n"
         "* Autoimpreso: Odoo imprime el comprobante completo (encabezado, número y CAI), por lo que "
         "el CAI, su vencimiento y el rango autorizado son obligatorios.\n"

--- a/l10n_ar_stock_preprinted/tests/__init__.py
+++ b/l10n_ar_stock_preprinted/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_voucher_print_mode

--- a/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
+++ b/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
@@ -5,6 +5,8 @@ from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 from odoo.tools.pdf import PdfWriter
 
+from ..models.stock_picking import L10N_AR_PREPRINTED_LINE_MARK
+
 
 def _pdf_with_pages(pages):
     """PDF en blanco de ``pages`` páginas, para no depender de wkhtmltopdf."""
@@ -140,3 +142,39 @@ class TestVoucherPrintMode(TransactionCase):
             patch.object(type(self.picking), "_l10n_ar_count_pages_with_products", return_value=2),
         ):
             self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 2)
+
+    def test_preprinted_forces_ar_delivery_report(self):
+        """Un tipo preimpreso usa el comprobante argentino aunque todavía NO tenga número de
+        remito: sin número se imprime como comprobante de entrega normal (no el remito de
+        Odoo) y el conteo de hojas fuerza el layout preimpreso; los dos necesitan el template
+        argentino. El core de l10n_ar_stock_ux solo lo elige cuando ya hay número."""
+        self.picking.company_id.country_id = self.env.ref("base.ar")
+        self.assertFalse(self.picking.l10n_ar_delivery_guide_number)
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            "l10n_ar_stock_ux.report_delivery_document",
+        )
+
+    def test_count_pages_by_line_mark(self):
+        """El contador cuenta solo las páginas que traen la marca de línea de producto: una
+        hoja de solo transportista / firma / totales (sin marca) no consume número."""
+
+        class _Page:
+            def __init__(self, text):
+                self._text = text
+
+            def extract_text(self):
+                return self._text
+
+        class _Reader:
+            def __init__(self, pages):
+                self.pages = pages
+
+        reader = _Reader(
+            [
+                _Page("Producto A " + L10N_AR_PREPRINTED_LINE_MARK),
+                _Page("Producto B " + L10N_AR_PREPRINTED_LINE_MARK),
+                _Page("Datos del transportista, sin líneas de producto"),
+            ]
+        )
+        self.assertEqual(self.picking._l10n_ar_count_pages_with_products(reader), 2)

--- a/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
+++ b/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
@@ -1,0 +1,135 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+from odoo.tools.pdf import PdfWriter
+
+
+def _pdf_with_pages(pages):
+    """PDF en blanco de ``pages`` páginas, para no depender de wkhtmltopdf."""
+    writer = PdfWriter()
+    for __ in range(pages):
+        writer.add_blank_page(width=595, height=842)
+    stream = BytesIO()
+    writer.write(stream)
+    return stream.getvalue()
+
+
+class TestVoucherPrintMode(TransactionCase):
+    """El modo de impresión del remito y la numeración que se deriva de él."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.document_type = cls.env.ref("l10n_ar.dc_r_r")
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito test",
+                "sequence_code": "TESTREM",
+                "code": "outgoing",
+                "company_id": cls.env.company.id,
+                "warehouse_id": cls.env["stock.warehouse"]
+                .search([("company_id", "=", cls.env.company.id)], limit=1)
+                .id,
+                "l10n_ar_document_type_id": cls.document_type.id,
+                "l10n_ar_voucher_print_mode": "preprinted",
+            }
+        )
+        cls.picking_type.l10n_ar_delivery_sequence_prefix = "00099"
+        cls.product = cls.env["product.product"].create({"name": "Producto remito test", "type": "consu"})
+        cls.picking = cls.env["stock.picking"].create(
+            {
+                "picking_type_id": cls.picking_type.id,
+                "location_id": cls.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": cls.env.ref("stock.stock_location_customers").id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "product_uom_qty": 1.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_preprinted_allows_empty_cai(self):
+        """En preimpreso el CAI y el rango no se cargan: vienen impresos en el papel."""
+        self.assertFalse(self.picking_type.l10n_ar_cai_authorization_code)
+        # no debería levantar la restricción
+        self.picking_type.write({"l10n_ar_voucher_print_mode": "preprinted"})
+        self.assertEqual(self.picking_type.l10n_ar_voucher_print_mode, "preprinted")
+
+    def test_autoprinted_requires_cai(self):
+        """En autoimpreso Odoo imprime el CAI, así que el CAI y su rango son obligatorios
+        incluso escribiendo por ORM (donde el required de la vista no aplica)."""
+        with self.assertRaises(ValidationError):
+            self.picking_type.write({"l10n_ar_voucher_print_mode": "autoprinted"})
+
+    def test_autoprinted_with_cai_is_valid(self):
+        self.picking_type.write(
+            {
+                "l10n_ar_voucher_print_mode": "autoprinted",
+                "l10n_ar_cai_authorization_code": "12345678901234",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "00000999",
+            }
+        )
+        self.assertEqual(self.picking_type.l10n_ar_voucher_print_mode, "autoprinted")
+
+    def test_print_mode_default_is_autoprinted(self):
+        """Los tipos de operación existentes y los nuevos siguen siendo autoimpresos."""
+        picking_type = self.env["stock.picking.type"].create(
+            {
+                "name": "Sin remito",
+                "sequence_code": "TESTNOREM",
+                "code": "internal",
+                "company_id": self.env.company.id,
+            }
+        )
+        self.assertEqual(picking_type.l10n_ar_voucher_print_mode, "autoprinted")
+
+    def test_preprinted_numbering_one_number_per_sheet(self):
+        """El preimpreso asigna un número por hoja consumida, separados por coma y sin CAI."""
+        with patch.object(type(self.picking), "_l10n_ar_count_preprinted_sheets", return_value=3):
+            self.picking.l10n_ar_action_create_delivery_guide()
+        numbers = self.picking.l10n_ar_delivery_guide_number.split(",")
+        self.assertEqual(len(numbers), 3)
+        self.assertEqual(numbers, sorted(numbers), "los números deben ser consecutivos")
+        self.assertEqual(
+            self.picking.l10n_ar_cai_data,
+            {"document_type_id": self.document_type.id},
+            "en preimpreso no se guardan datos de CAI: vienen impresos en el papel",
+        )
+
+    def test_preprinted_numbering_is_idempotent(self):
+        """Reimprimir no consume números nuevos."""
+        with patch.object(type(self.picking), "_l10n_ar_count_preprinted_sheets", return_value=2):
+            self.picking.l10n_ar_action_create_delivery_guide()
+            numbers = self.picking.l10n_ar_delivery_guide_number
+            self.picking.l10n_ar_action_create_delivery_guide()
+        self.assertEqual(self.picking.l10n_ar_delivery_guide_number, numbers)
+
+    def test_sheet_count_ignores_report_copies(self):
+        """El reporte repite el comprobante una vez por copia (duplicado / triplicado) y el
+        juego de copias consume un solo número por hoja: 6 páginas en triplicado son 2 hojas."""
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = "triplicado"
+        with (
+            patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(6), "pdf")),
+            patch.object(type(self.picking), "_l10n_ar_count_pages_with_products", return_value=6),
+        ):
+            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 2)
+
+    def test_sheet_count_without_copies(self):
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = False
+        with (
+            patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(2), "pdf")),
+            patch.object(type(self.picking), "_l10n_ar_count_pages_with_products", return_value=2),
+        ):
+            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 2)

--- a/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
+++ b/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
@@ -99,7 +99,14 @@ class TestVoucherPrintMode(TransactionCase):
             self.picking.l10n_ar_action_create_delivery_guide()
         numbers = self.picking.l10n_ar_delivery_guide_number.split(",")
         self.assertEqual(len(numbers), 3)
-        self.assertEqual(numbers, sorted(numbers), "los números deben ser consecutivos")
+        # los números tienen la forma <prefijo>-<8 dígitos>: comparamos la parte numérica
+        # contra un range para verificar que sean consecutivos y sin huecos
+        sequence_numbers = [int(number.split("-")[-1]) for number in numbers]
+        self.assertEqual(
+            sequence_numbers,
+            list(range(sequence_numbers[0], sequence_numbers[0] + 3)),
+            "los números deben ser consecutivos y sin huecos",
+        )
         self.assertEqual(
             self.picking.l10n_ar_cai_data,
             {"document_type_id": self.document_type.id},

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -12,13 +12,13 @@
 
         <!-- pre_printed_report gobierna el blanqueo del encabezado loc arg y oculta el CAI -->
         <xpath expr="//t[@t-set='pre_printed_report']" position="attributes">
-            <attribute name="t-value">o.l10n_ar_is_preprinted</attribute>
+            <attribute name="t-value">o.l10n_ar_voucher_print_mode == 'preprinted'</attribute>
         </xpath>
 
         <!-- En preimpreso el pie queda vacío (sin firma, sin paginador, sin CAI). Lo dejamos
              truthy pero en blanco para que el layout NO caiga al pie estándar de Odoo. -->
         <xpath expr="//t[@t-set='custom_footer']" position="after">
-            <t t-if="o.l10n_ar_is_preprinted" t-set="custom_footer">
+            <t t-if="o.l10n_ar_voucher_print_mode == 'preprinted'" t-set="custom_footer">
                 <span/>
             </t>
         </xpath>

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- En remitos preimpresos el papel de imprenta ya trae encabezado, numeración y CAI.
+         Por eso, cuando el tipo de operación es preimpreso, el reporte solo imprime el
+         contenido variable: activamos pre_printed_report y suprimimos encabezado y número. -->
+    <template id="report_delivery_document_preprinted"
+              inherit_id="l10n_ar_stock_ux.report_delivery_document">
+
+        <xpath expr="//t[@t-set='pre_printed_report']" position="attributes">
+            <attribute name="t-value">o.l10n_ar_is_preprinted</attribute>
+        </xpath>
+
+        <xpath expr="//t[@t-set='custom_header']" position="attributes">
+            <attribute name="t-value">not o.l10n_ar_is_preprinted and o.company_id.country_id.code == 'AR' and 'l10n_ar.custom_header' or False</attribute>
+        </xpath>
+
+        <xpath expr="//t[@t-set='report_number']" position="attributes">
+            <attribute name="t-value">not o.l10n_ar_is_preprinted and (o.l10n_ar_delivery_guide_number or o.name) or False</attribute>
+        </xpath>
+
+    </template>
+</odoo>

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- En remitos preimpresos el papel de imprenta ya trae encabezado, numeración y CAI.
-         Por eso, cuando el tipo de operación es preimpreso, el reporte solo imprime el
-         contenido variable: activamos pre_printed_report y suprimimos encabezado y número. -->
+         Por eso solo imprimimos el contenido variable: activamos pre_printed_report, que
+         hace que el encabezado de la localización argentina se renderice en blanco dejando
+         únicamente la fecha del comprobante, y vaciamos el pie de página. Mantenemos el
+         encabezado de la loc arg (custom_header) — NO lo ponemos en False — porque hacerlo
+         haría caer el reporte al encabezado estándar de Odoo (logo + datos de la empresa),
+         que es justo lo que no queremos en un remito preimpreso. -->
     <template id="report_delivery_document_preprinted"
               inherit_id="l10n_ar_stock_ux.report_delivery_document">
 
+        <!-- pre_printed_report gobierna el blanqueo del encabezado loc arg y oculta el CAI -->
         <xpath expr="//t[@t-set='pre_printed_report']" position="attributes">
             <attribute name="t-value">o.l10n_ar_is_preprinted</attribute>
         </xpath>
 
-        <xpath expr="//t[@t-set='custom_header']" position="attributes">
-            <attribute name="t-value">not o.l10n_ar_is_preprinted and o.company_id.country_id.code == 'AR' and 'l10n_ar.custom_header' or False</attribute>
-        </xpath>
-
-        <xpath expr="//t[@t-set='report_number']" position="attributes">
-            <attribute name="t-value">not o.l10n_ar_is_preprinted and (o.l10n_ar_delivery_guide_number or o.name) or False</attribute>
+        <!-- En preimpreso el pie queda vacío (sin firma, sin paginador, sin CAI). Lo dejamos
+             truthy pero en blanco para que el layout NO caiga al pie estándar de Odoo. -->
+        <xpath expr="//t[@t-set='custom_footer']" position="after">
+            <t t-if="o.l10n_ar_is_preprinted" t-set="custom_footer">
+                <span/>
+            </t>
         </xpath>
 
     </template>

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -6,22 +6,48 @@
          únicamente la fecha del comprobante, y vaciamos el pie de página. Mantenemos el
          encabezado de la loc arg (custom_header) — NO lo ponemos en False — porque hacerlo
          haría caer el reporte al encabezado estándar de Odoo (logo + datos de la empresa),
-         que es justo lo que no queremos en un remito preimpreso. -->
+         que es justo lo que no queremos en un remito preimpreso.
+
+         El modo preimpreso del reporte se aplica solo cuando el remito ya tiene número
+         asignado (l10n_ar_delivery_guide_number) o cuando estamos contando hojas
+         (contexto l10n_ar_counting). Sin número asignado el picking se imprime como el
+         comprobante de entrega normal (con encabezado y pie), que es lo que se espera
+         cuando todavía no se generó la guía. -->
     <template id="report_delivery_document_preprinted"
               inherit_id="l10n_ar_stock_ux.report_delivery_document">
 
         <!-- pre_printed_report gobierna el blanqueo del encabezado loc arg y oculta el CAI -->
         <xpath expr="//t[@t-set='pre_printed_report']" position="attributes">
-            <attribute name="t-value">o.l10n_ar_voucher_print_mode == 'preprinted'</attribute>
+            <attribute name="t-value">o.l10n_ar_voucher_print_mode == 'preprinted' and (o.l10n_ar_delivery_guide_number or o.env.context.get('l10n_ar_counting'))</attribute>
         </xpath>
 
         <!-- En preimpreso el pie queda vacío (sin firma, sin paginador, sin CAI). Lo dejamos
              truthy pero en blanco para que el layout NO caiga al pie estándar de Odoo. -->
         <xpath expr="//t[@t-set='custom_footer']" position="after">
-            <t t-if="o.l10n_ar_voucher_print_mode == 'preprinted'" t-set="custom_footer">
+            <t t-if="o.l10n_ar_voucher_print_mode == 'preprinted' and (o.l10n_ar_delivery_guide_number or o.env.context.get('l10n_ar_counting'))" t-set="custom_footer">
                 <span/>
             </t>
         </xpath>
 
+    </template>
+
+    <!-- Marca invisible por línea de producto, solo cuando renderizamos para contar hojas
+         (contexto l10n_ar_counting). Es texto blanco de 1px: queda en la capa de texto del
+         PDF (la lee _l10n_ar_count_pages_with_products) pero no se ve. Así una hoja con
+         productos trae al menos una marca y una hoja de solo transportista / firma / totales
+         no, sin depender de que el producto tenga código. Se marcan los dos leaf-templates
+         que usa un picking validado (líneas agregadas y líneas con número de serie). -->
+    <template id="stock_report_delivery_aggregated_move_lines_preprinted"
+              inherit_id="stock.stock_report_delivery_aggregated_move_lines">
+        <xpath expr="//tr/td[1]/span[1]" position="after">
+            <span t-if="o.env.context.get('l10n_ar_counting')" style="color:#ffffff;font-size:1px">PREPRINTEDLINEMARK</span>
+        </xpath>
+    </template>
+
+    <template id="stock_report_delivery_has_serial_move_line_preprinted"
+              inherit_id="stock.stock_report_delivery_has_serial_move_line">
+        <xpath expr="//span[@t-field='move_line.product_id']" position="after">
+            <span t-if="o.env.context.get('l10n_ar_counting')" style="color:#ffffff;font-size:1px">PREPRINTEDLINEMARK</span>
+        </xpath>
     </template>
 </odoo>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Habilitamos el caso "preimpreso": tipo de documento de remito SIN CAI.
+         Para eso relajamos el required del CAI (y de los datos que solo aplican al
+         autoimpreso) y agregamos los renglones por remito. -->
+    <record id="view_picking_type_form_preprinted" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.preprinted</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
+        <field name="arch" type="xml">
+            <!-- CAI opcional: su presencia distingue autoimpreso (con CAI) de preimpreso (sin CAI) -->
+            <field name="l10n_ar_cai_authorization_code" position="attributes">
+                <attribute name="required">0</attribute>
+            </field>
+            <!-- estos datos solo son obligatorios cuando hay CAI (autoimpreso) -->
+            <field name="l10n_ar_cai_expiration_date" position="attributes">
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+            </field>
+            <field name="l10n_ar_sequence_number_start" position="attributes">
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+            </field>
+            <field name="l10n_ar_sequence_number_end" position="attributes">
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+            </field>
+            <!-- renglones por hoja: solo aplica al preimpreso (doc type sin CAI) -->
+            <field name="l10n_ar_next_delivery_number" position="after">
+                <field name="l10n_ar_lines_per_voucher"
+                       invisible="not l10n_ar_document_type_id or l10n_ar_cai_authorization_code"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -8,24 +8,31 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- CAI opcional: su presencia distingue autoimpreso (con CAI) de preimpreso (sin CAI) -->
-            <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">0</attribute>
+            <!-- toggle Autoimpreso: define si el remito es autoimpreso (con CAI) o preimpreso -->
+            <field name="l10n_ar_document_type_id" position="after">
+                <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- estos datos solo son obligatorios cuando hay CAI (autoimpreso) -->
+            <!-- el CAI y su rango solo aplican (y son obligatorios) en autoimpreso -->
+            <field name="l10n_ar_cai_authorization_code" position="attributes">
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+            </field>
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
-            <!-- renglones por hoja: solo aplica al preimpreso (doc type sin CAI) -->
+            <!-- renglones por hoja: solo aplica al preimpreso -->
             <field name="l10n_ar_next_delivery_number" position="after">
                 <field name="l10n_ar_lines_per_voucher"
-                       invisible="not l10n_ar_document_type_id or l10n_ar_cai_authorization_code"/>
+                       invisible="not l10n_ar_document_type_id or l10n_ar_autoprinted"/>
             </field>
         </field>
     </record>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,38 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- Habilitamos el caso "preimpreso": tipo de documento de remito SIN CAI.
-         Para eso relajamos el required del CAI (y de los datos que solo aplican al
-         autoimpreso) y agregamos los renglones por remito. -->
+         El casillero Autoimpreso se autocalcula según el CAI (con CAI = autoimpreso).
+         Relajamos la obligatoriedad del CAI y ocultamos sus datos cuando es preimpreso. -->
     <record id="view_picking_type_form_preprinted" model="ir.ui.view">
         <field name="name">stock.picking.type.form.preprinted</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- toggle Autoimpreso: define si el remito es autoimpreso (con CAI) o preimpreso -->
+            <!-- indicador Autoimpreso (solo lectura, computado del CAI) -->
             <field name="l10n_ar_document_type_id" position="after">
                 <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- el CAI y su rango solo aplican (y son obligatorios) en autoimpreso -->
+            <!-- CAI opcional: su presencia define autoimpreso vs preimpreso -->
             <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">0</attribute>
             </field>
+            <!-- vencimiento y rango solo aplican (y son obligatorios) cuando hay CAI -->
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_document_type_id and l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
-            </field>
-            <!-- renglones por hoja: solo aplica al preimpreso -->
-            <field name="l10n_ar_next_delivery_number" position="after">
-                <field name="l10n_ar_lines_per_voucher"
-                       invisible="not l10n_ar_document_type_id or l10n_ar_autoprinted"/>
+                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
             </field>
         </field>
     </record>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- El casillero Autoimpreso gobierna el CAI: al activarlo, el CAI y su vencimiento
-         (y el rango autorizado) se vuelven visibles y obligatorios; al desactivarlo se
-         ocultan y el tipo de operación queda como preimpreso. -->
+    <!-- El Modo de Impresión del Remito gobierna el CAI: en autoimpreso (default) la vista
+         queda como la del core (CAI, vencimiento y rango visibles y obligatorios, porque
+         Odoo los imprime); al pasar a preimpreso esos campos se ocultan y dejan de pedirse
+         porque ya vienen impresos en el papel de la imprenta. El prefijo (punto de venta) y
+         el próximo número siguen visibles en los dos modos: en preimpreso la secuencia tiene
+         que arrancar en el número de la primera hoja del talonario. -->
     <record id="view_picking_type_form_preprinted" model="ir.ui.view">
         <field name="name">stock.picking.type.form.preprinted</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- Autoimpreso: booleano editable, solo relevante en tipos de operación con remito -->
+            <!-- Modo de impresión: solo relevante en tipos de operación con remito -->
             <field name="l10n_ar_document_type_id" position="after">
-                <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
+                <field name="l10n_ar_voucher_print_mode" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- CAI: visible y obligatorio solo cuando es autoimpreso -->
+            <!-- CAI: visible y obligatorio solo en autoimpreso -->
             <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_voucher_print_mode == 'autoprinted'</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or l10n_ar_voucher_print_mode == 'preprinted'</attribute>
             </field>
             <!-- Vencimiento y rango del CAI: mismo criterio que el CAI -->
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_voucher_print_mode == 'autoprinted'</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or l10n_ar_voucher_print_mode == 'preprinted'</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_voucher_print_mode == 'autoprinted'</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or l10n_ar_voucher_print_mode == 'preprinted'</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_autoprinted</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
+                <attribute name="required">l10n_ar_document_type_id and l10n_ar_voucher_print_mode == 'autoprinted'</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or l10n_ar_voucher_print_mode == 'preprinted'</attribute>
             </field>
         </field>
     </record>

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -1,33 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <!-- Habilitamos el caso "preimpreso": tipo de documento de remito SIN CAI.
-         El casillero Autoimpreso se autocalcula según el CAI (con CAI = autoimpreso).
-         Relajamos la obligatoriedad del CAI y ocultamos sus datos cuando es preimpreso. -->
+    <!-- El casillero Autoimpreso gobierna el CAI: al activarlo, el CAI y su vencimiento
+         (y el rango autorizado) se vuelven visibles y obligatorios; al desactivarlo se
+         ocultan y el tipo de operación queda como preimpreso. -->
     <record id="view_picking_type_form_preprinted" model="ir.ui.view">
         <field name="name">stock.picking.type.form.preprinted</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
         <field name="arch" type="xml">
-            <!-- indicador Autoimpreso (solo lectura, computado del CAI) -->
+            <!-- Autoimpreso: booleano editable, solo relevante en tipos de operación con remito -->
             <field name="l10n_ar_document_type_id" position="after">
                 <field name="l10n_ar_autoprinted" invisible="not l10n_ar_document_type_id"/>
             </field>
-            <!-- CAI opcional: su presencia define autoimpreso vs preimpreso -->
+            <!-- CAI: visible y obligatorio solo cuando es autoimpreso -->
             <field name="l10n_ar_cai_authorization_code" position="attributes">
-                <attribute name="required">0</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
-            <!-- vencimiento y rango solo aplican (y son obligatorios) cuando hay CAI -->
+            <!-- Vencimiento y rango del CAI: mismo criterio que el CAI -->
             <field name="l10n_ar_cai_expiration_date" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_start" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
             <field name="l10n_ar_sequence_number_end" position="attributes">
-                <attribute name="required">l10n_ar_cai_authorization_code</attribute>
-                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_cai_authorization_code</attribute>
+                <attribute name="required">l10n_ar_autoprinted</attribute>
+                <attribute name="invisible">not l10n_ar_document_type_id or not l10n_ar_autoprinted</attribute>
             </field>
         </field>
     </record>

--- a/l10n_ar_stock_ux/tests/test_stock_picking_type.py
+++ b/l10n_ar_stock_ux/tests/test_stock_picking_type.py
@@ -45,6 +45,11 @@ class TestL10nArStockUxSharedSequence(TestArCommon):
                 "l10n_ar_document_type_id": document_type.id,
                 "l10n_ar_cai_authorization_code": "99999999999999",
                 "l10n_ar_cai_expiration_date": "2030-12-31",
+                # el rango autorizado del CAI va junto con el resto: la vista del core lo pide
+                # required cuando hay tipo de documento, y l10n_ar_stock_preprinted lo exige
+                # también del lado del servidor cuando el remito es autoimpreso
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "99999999",
                 "l10n_ar_delivery_sequence_prefix": prefix,
                 "l10n_ar_next_delivery_number": next_number,
             }


### PR DESCRIPTION
Variante de #311 para poder probar las dos en runbot. Contiene los commits de #311 más tres propios encima. Se mergea una sola de las dos: si se elige esta, #311 se cierra.

Diferencias contra #311, commit por commit.

## `[REF] single stored field for the print mode`

Reemplaza el par `l10n_ar_autoprinted` (booleano almacenado) + `l10n_ar_is_preprinted` (computado) por un único campo almacenado en el tipo de operación:

```python
l10n_ar_voucher_print_mode = fields.Selection(
    selection=[("autoprinted", "Autoimpreso"), ("preprinted", "Preimpreso")],
    default="autoprinted",
)
```

- El modo de impresión es **una decisión explícita**, no dos campos. El derivado se usaba en dos lugares (reporte y numeración) y las vistas escribían la condición a mano igual.
- **No conviene derivarlo de "el CAI está vacío".** Un modo derivado no distingue *"tipo autoimpreso al que todavía le falta cargar el CAI"* de *"tipo preimpreso"*: una configuración incompleta imprimiría un remito sin encabezado, sin número y sin CAI en vez de fallar. Y al vencer el CAI, borrar el viejo para cargar el nuevo convertiría el tipo en preimpreso en silencio.
- Selection en vez de booleano: nombra los dos estados sin doble negación y deja lugar a un tercero sin migración. Es también cómo la loc modela lo mismo en facturas (`l10n_ar_afip_pos_system == 'II_IM'`).
- Antecedente: en 18.0 (`ingadhoc/stock`, `stock_voucher_ux`) había **un** campo almacenado, `stock.book.autoprinted`, y el "preimpreso" no era un campo sino una expresión inline en el reporte.

Se agrega un `@api.constrains` que exige CAI, vencimiento y rango cuando el modo es autoimpreso: el `required` de la vista no cubre imports, data XML ni escrituras por ORM.

UI: autoimpreso (default) deja la vista igual a la del core. Al pasar a preimpreso se ocultan CAI, vencimiento y rango. El prefijo (punto de venta) y el próximo número se siguen pidiendo en los dos modos, porque en preimpreso la secuencia tiene que arrancar en el número de la primera hoja del talonario.

## `[FIX] count sheets on the printed layout and one copy`

Dos problemas del conteo de hojas, los dos con antecedente en 18.0:

- **Copias.** `l10n_ar_ux` repite el comprobante completo una vez por copia configurada en el reporte (duplicado / triplicado) y el juego carbónico consume **un** número por hoja. Contando páginas con productos sobre el PDF entero se asignaban 2x / 3x los números. Se acota el conteo a las páginas de una sola copia, como hacía el controller de 18.0 (`stock_voucher_ux/controllers/main.py`, `min(number_pages, total_pages)`). Solo se manifiesta si el reporte de remito tiene duplicado/triplicado configurado; con el default (sin copias) el conteo ya daba bien.
- **Layout.** El PDF se renderiza antes de asignar el número, y `l10n_ar_stock_ux._get_name_delivery_report()` elige el template argentino solo cuando el picking ya tiene número. O sea: se contaban hojas del remito estándar de Odoo, que pagina distinto al que se imprime. Se fuerza el template argentino durante el conteo.

Además se usa `odoo.tools.pdf.PdfReader` en lugar de importar `PyPDF2` / `pypdf` a mano.

## `[ADD] tests`

8 tests: contrato del modo (default autoimpreso, CAI exigido por el constrains en autoimpreso, no pedido en preimpreso) y numeración del preimpreso (un número por hoja, coma-separados, sin datos de CAI, sin consumir números nuevos al reimprimir). El conteo de hojas se testea con un PDF en blanco armado con `odoo.tools.pdf`, así no depende de wkhtmltopdf: 6 páginas con el reporte en triplicado tienen que contarse como 2 hojas.

## Verificación local

Base 19.0 con `l10n_ar`, `l10n_ar_ux`, `l10n_ar_stock`, `l10n_ar_stock_ux` y `l10n_ar_stock_picking_batch` instalados:

- Instalación del módulo: OK (`-i l10n_ar_stock_preprinted --stop-after-init`, exit 0).
- Tests del módulo: `0 failed, 0 error(s) of 8 tests`.
- Los tests de `l10n_ar_stock` no corren en esa base por un problema previo y ajeno a este cambio (el `setUpClass` de `mail` pisa el país del partner admin y el CUIT deja de validar). Verificado con una base de control con el módulo desinstalado: falla igual.
- Pre-commit en verde sobre todos los archivos tocados.

Falta la prueba funcional en runbot: form del tipo de operación en los dos modos, y numeración + PDF de un remito multi-hoja con el reporte en triplicado.

## Lo que sigue pendiente (igual que en #311)

- La heurística de "página con productos" (matchear `default_code` / `barcode` en el texto extraído) viene copiada del controller de 18.0. Es frágil para algo con valor legal: depende de que el reporte imprima el código, y el fallback `\d+[.,]\d+` matchea cualquier decimal. La alternativa determinística es forzar N renglones por hoja en el layout y calcular `ceil(renglones / renglones_por_hoja)` — ojo que la estimación por renglones sola ya se descartó en 18.0 por subnumerar (`lines_per_voucher` quedó invisible).
- `_action_done` con autoasignación renderiza un PDF por picking dentro de la transacción de validación en preimpreso.
- En preimpreso no queda validación de rango, aunque el papel de imprenta también trae uno (en 18.0 pasaba lo mismo).
- Falta el puente para lotes: `l10n_ar_stock_picking_batch` tiene su propio template y su propio `l10n_ar_action_create_delivery_guide`.
- Falta i18n.
