### PR TITLE
[FIX] l10n_ar_stock_ux: avoid KeyError rendering CAI on delivery report

### DIFF
--- a/l10n_ar_stock_ux/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_ux/views/report_deliveryslip.xml
@@ -83,10 +83,10 @@
                     </div>
 
                     <div name="footer_right_column" class="col-4 text-right">
-                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data">
-                            CAI: <span t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
+                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data.get('cai_authorization_code')">
+                            CAI: <span t-out="o.l10n_ar_cai_data.get('cai_authorization_code')"/>
                         </div>
-                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data">
+                        <div t-if="not pre_printed_report and o.l10n_ar_cai_expiration_date">
                             CAI Due Date: <span t-field="o.l10n_ar_cai_expiration_date"/>
                         </div>
                         <div name="pager" t-if="report_type == 'pdf'">


### PR DESCRIPTION
### Problem

The delivery report template `l10n_ar_stock_ux.report_delivery_document` renders the CAI block with subscript access:

```xml
<div t-if="not pre_printed_report and o.l10n_ar_cai_data">
    CAI: <span t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
</div>
```

The guard only checks that `l10n_ar_cai_data` is a truthy dict, not that it contains the `cai_authorization_code` key. When the picking's `l10n_ar_cai_data` is a non-empty dict that does not carry that key (e.g. it only holds `document_type_id`), rendering raises:

```
KeyError: 'cai_authorization_code'
Template: l10n_ar_stock_ux.report_delivery_document
Element: <span t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
```

and the PDF fails to render.

### Fix

- Guard the CAI block on the key itself using `.get('cai_authorization_code')` (matching the defensive pattern already used in `_compute_l10n_ar_afip_barcode`) and read it the same way.
- Render the *CAI Due Date* block based on the computed `l10n_ar_cai_expiration_date` instead of the raw dict, so a partial CAI data dict does not print an empty due-date row either.

No behavioral change when the full CAI data is present; the report simply no longer crashes when the authorization code is absent.