### PR TITLE
[FIX] l10n_ar_stock_ux: el comprobante AR se rompe sin datos de CAI (regresión en 19.0)

### DIFF
--- a/l10n_ar_stock_picking_batch/report/report_batch_deliveryslip.xml
+++ b/l10n_ar_stock_picking_batch/report/report_batch_deliveryslip.xml
@@ -100,10 +100,14 @@
                     </div>
 
                     <div name="footer_right_column" class="col-4 text-right">
-                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data">
-                            CAI: <span t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
+                        <!-- Mismo criterio que en l10n_ar_stock_ux: l10n_ar_cai_data es un
+                             fields.Json que vale False cuando no hay datos, y el dict puede no
+                             traer la clave del CAI (un remito preimpreso no tiene CAI: viene
+                             impreso en el papel). -->
+                        <div t-if="not pre_printed_report and (o.l10n_ar_cai_data or {}).get('cai_authorization_code')">
+                            CAI: <span t-out="(o.l10n_ar_cai_data or {}).get('cai_authorization_code')"/>
                         </div>
-                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data">
+                        <div t-if="not pre_printed_report and o.l10n_ar_cai_expiration_date">
                             CAI Due Date: <span t-field="o.l10n_ar_cai_expiration_date"/>
                         </div>
                         <div name="pager" t-if="report_type == 'pdf'">

--- a/l10n_ar_stock_picking_batch/tests/__init__.py
+++ b/l10n_ar_stock_picking_batch/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_report_batch_delivery

--- a/l10n_ar_stock_picking_batch/tests/test_report_batch_delivery.py
+++ b/l10n_ar_stock_picking_batch/tests/test_report_batch_delivery.py
@@ -1,0 +1,115 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestL10nArBatchDeliveryReport(TransactionCase):
+    """El comprobante de entrega del lote lee ``l10n_ar_cai_data`` del primer remito numerado.
+
+    Ese dict puede no traer el código de CAI (un remito preimpreso no lo tiene: viene impreso
+    en el papel de la imprenta) y el campo puede valer ``False`` cuando ningún remito del lote
+    está numerado, porque es un ``fields.Json``. El pie tiene que aguantar los dos casos.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.country_id = cls.env.ref("base.ar")
+        cls.document_type = cls.env.ref("l10n_ar.dc_r_r")
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito test lote",
+                "sequence_code": "TESTBATREM",
+                "code": "outgoing",
+                "company_id": cls.env.company.id,
+                "warehouse_id": cls.env["stock.warehouse"]
+                .search([("company_id", "=", cls.env.company.id)], limit=1)
+                .id,
+                "l10n_ar_document_type_id": cls.document_type.id,
+                # tipo autoimpreso normal: Odoo imprime el CAI, así que va configurado
+                "l10n_ar_cai_authorization_code": "12345678901234",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "00000999",
+            }
+        )
+        product = cls.env["product.product"].create({"name": "Producto lote test", "type": "consu"})
+        cls.picking = cls.env["stock.picking"].create(
+            {
+                "picking_type_id": cls.picking_type.id,
+                "partner_id": cls.env["res.partner"].create({"name": "Cliente lote test"}).id,
+                "location_id": cls.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": cls.env.ref("stock.stock_location_customers").id,
+                "move_ids": [(0, 0, {"product_id": product.id, "product_uom_qty": 1.0})],
+            }
+        )
+        cls.batch = cls.env["stock.picking.batch"].create(
+            {
+                "name": "Lote test remito",
+                "picking_type_id": cls.picking_type.id,
+                "company_id": cls.env.company.id,
+                "picking_ids": [(6, 0, cls.picking.ids)],
+            }
+        )
+
+    def _render(self):
+        return self.env["ir.actions.report"]._render_qweb_html(
+            "stock_batch_picking_ux.action_report_batch_deliveryslip", self.batch.ids
+        )[0]
+
+    def _assert_no_cai_block(self):
+        # comparamos así y no con assertNotIn para no volcar el HTML entero al fallar
+        self.assertFalse(b"CAI:" in self._render(), "el pie no tiene que imprimir el bloque de CAI")
+
+    def test_renders_without_cai_data(self):
+        """Ningún remito del lote está numerado: l10n_ar_cai_data vale False."""
+        self.assertFalse(self.batch.l10n_ar_cai_data)
+        self._assert_no_cai_block()
+
+    def test_renders_with_cai_data_without_authorization_code(self):
+        """Remito preimpreso adentro del lote: el dict no trae el código de CAI."""
+        self.picking.write(
+            {
+                "l10n_ar_delivery_guide_number": "00099-00000001",
+                "l10n_ar_cai_data": {
+                    "document_type_id": self.document_type.id,
+                    "cai_authorization_code": False,
+                    "cai_expiration_date": False,
+                    "sequence_number_start": False,
+                    "sequence_number_end": False,
+                },
+            }
+        )
+        self.batch.invalidate_recordset()
+        self._assert_no_cai_block()
+
+    def test_renders_with_partial_cai_data(self):
+        """Datos ya guardados en base: los remitos preimpresos numerados con la primera
+        versión del módulo dejaron un dict con solo document_type_id, y ahí el lote rompía
+        con KeyError: 'cai_authorization_code'."""
+        self.picking.write(
+            {
+                "l10n_ar_delivery_guide_number": "00099-00000001",
+                "l10n_ar_cai_data": {"document_type_id": self.document_type.id},
+            }
+        )
+        self.batch.invalidate_recordset()
+        self._assert_no_cai_block()
+
+    def test_renders_with_full_cai_data(self):
+        """Remito autoimpreso: el CAI sale impreso en el pie del lote."""
+        self.picking.write(
+            {
+                "l10n_ar_delivery_guide_number": "00099-00000001",
+                "l10n_ar_cai_data": {
+                    "document_type_id": self.document_type.id,
+                    "cai_authorization_code": "12345678901234",
+                    "cai_expiration_date": "2030-12-31",
+                    "sequence_number_start": "00000001",
+                    "sequence_number_end": "00000999",
+                },
+            }
+        )
+        self.batch.invalidate_recordset()
+        html = self._render()
+        self.assertIn(b"12345678901234", html)

--- a/l10n_ar_stock_ux/tests/__init__.py
+++ b/l10n_ar_stock_ux/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_report_delivery
 from . import test_stock_picking_type

--- a/l10n_ar_stock_ux/tests/test_report_delivery.py
+++ b/l10n_ar_stock_ux/tests/test_report_delivery.py
@@ -1,0 +1,103 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestL10nArStockUxDeliveryReport(TransactionCase):
+    """El comprobante de entrega argentino se usa para TODA transferencia de compañía AR,
+    tenga o no remito generado, así que tiene que renderizar sin datos de CAI.
+
+    ``l10n_ar_cai_data`` es un ``fields.Json``: con la columna en NULL el ORM devuelve
+    ``False`` (no un dict vacío), y además un remito preimpreso no guarda el código de CAI
+    porque viene impreso en el papel. El pie del comprobante tiene que aguantar los dos casos.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.country_id = cls.env.ref("base.ar")
+        cls.document_type = cls.env.ref("l10n_ar.dc_r_r")
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito test reporte",
+                "sequence_code": "TESTREPREM",
+                "code": "outgoing",
+                "company_id": cls.env.company.id,
+                "warehouse_id": cls.env["stock.warehouse"]
+                .search([("company_id", "=", cls.env.company.id)], limit=1)
+                .id,
+                "l10n_ar_document_type_id": cls.document_type.id,
+                # tipo autoimpreso normal: Odoo imprime el CAI, así que va configurado
+                "l10n_ar_cai_authorization_code": "12345678901234",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "00000999",
+            }
+        )
+        product = cls.env["product.product"].create({"name": "Producto reporte test", "type": "consu"})
+        cls.picking = cls.env["stock.picking"].create(
+            {
+                "picking_type_id": cls.picking_type.id,
+                "partner_id": cls.env["res.partner"].create({"name": "Cliente reporte test"}).id,
+                "location_id": cls.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": cls.env.ref("stock.stock_location_customers").id,
+                "move_ids": [(0, 0, {"product_id": product.id, "product_uom_qty": 1.0})],
+            }
+        )
+
+    def _render(self):
+        return self.env["ir.actions.report"]._render_qweb_html("stock.action_report_delivery", self.picking.ids)[0]
+
+    def _assert_no_cai_block(self):
+        # comparamos así y no con assertNotIn para no volcar el HTML entero al fallar
+        self.assertFalse(b"CAI:" in self._render(), "el pie no tiene que imprimir el bloque de CAI")
+
+    def test_renders_without_cai_data(self):
+        """Sin remito generado no hay datos de CAI y el campo Json vale False."""
+        self.assertFalse(self.picking.l10n_ar_cai_data)
+        self._assert_no_cai_block()
+
+    def test_renders_with_cai_data_without_authorization_code(self):
+        """Remito preimpreso: el dict trae las claves pero el CAI viene en blanco."""
+        self.picking.write(
+            {
+                "l10n_ar_delivery_guide_number": "00099-00000001",
+                "l10n_ar_cai_data": {
+                    "document_type_id": self.document_type.id,
+                    "cai_authorization_code": False,
+                    "cai_expiration_date": False,
+                    "sequence_number_start": False,
+                    "sequence_number_end": False,
+                },
+            }
+        )
+        self._assert_no_cai_block()
+
+    def test_renders_with_partial_cai_data(self):
+        """Datos ya guardados en base: los remitos preimpresos numerados con la primera
+        versión del módulo dejaron un dict con solo document_type_id. El reporte no puede
+        romper con esos registros."""
+        self.picking.write(
+            {
+                "l10n_ar_delivery_guide_number": "00099-00000001",
+                "l10n_ar_cai_data": {"document_type_id": self.document_type.id},
+            }
+        )
+        self._assert_no_cai_block()
+
+    def test_renders_with_full_cai_data(self):
+        """Remito autoimpreso: el CAI y su vencimiento salen impresos."""
+        self.picking.write(
+            {
+                "l10n_ar_delivery_guide_number": "00099-00000001",
+                "l10n_ar_cai_data": {
+                    "document_type_id": self.document_type.id,
+                    "cai_authorization_code": "12345678901234",
+                    "cai_expiration_date": "2030-12-31",
+                    "sequence_number_start": "00000001",
+                    "sequence_number_end": "00000999",
+                },
+            }
+        )
+        html = self._render()
+        self.assertIn(b"12345678901234", html)

--- a/l10n_ar_stock_ux/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_ux/views/report_deliveryslip.xml
@@ -83,8 +83,12 @@
                     </div>
 
                     <div name="footer_right_column" class="col-4 text-right">
-                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data.get('cai_authorization_code')">
-                            CAI: <span t-out="o.l10n_ar_cai_data.get('cai_authorization_code')"/>
+                        <!-- l10n_ar_cai_data es un fields.Json: con la columna en NULL el ORM
+                             devuelve False, así que normalizamos antes de leer la clave. Y la
+                             leemos con .get() porque el dict puede no traerla (un remito
+                             preimpreso no tiene CAI: viene impreso en el papel). -->
+                        <div t-if="not pre_printed_report and (o.l10n_ar_cai_data or {}).get('cai_authorization_code')">
+                            CAI: <span t-out="(o.l10n_ar_cai_data or {}).get('cai_authorization_code')"/>
                         </div>
                         <div t-if="not pre_printed_report and o.l10n_ar_cai_expiration_date">
                             CAI Due Date: <span t-field="o.l10n_ar_cai_expiration_date"/>


### PR DESCRIPTION
⚠️ **`19.0` está roto ahora mismo y esto lo arregla.** #319 entró (`4f74543`) y su guard rompe el comprobante de entrega de **toda transferencia AR que no tenga datos de CAI**, que después de #317 es la gran mayoría. Tarea 71244.

## Lo que está pasando en `19.0`

```xml
<div t-if="not pre_printed_report and o.l10n_ar_cai_data.get('cai_authorization_code')">
```

`l10n_ar_cai_data` es un `fields.Json`, y con la columna en `NULL` el ORM devuelve **`False`**, no `{}`:

```python
# odoo/orm/fields_misc.py
class Json(Field):
    def convert_to_record(self, value, record):
        return False if value is None else copy.deepcopy(value)
```

El guard anterior (`and o.l10n_ar_cai_data`) cortaba por short-circuit justo en ese caso. El `.get()` se evalúa siempre que `pre_printed_report` sea falso — o sea, siempre en una instalación normal. Reproducido recién sobre `origin/19.0` puro, sin nada de esta rama aplicado, con una transferencia AR recién creada:

```
==============================================================================
Transferencia AR sin remito generado
==============================================================================
l10n_ar_cai_data      : False
tipo                  : bool
reporte que le toca   : l10n_ar_stock_ux.report_delivery_document
RESULTADO: EXPLOTA -> QWebError
   AttributeError: 'bool' object has no attribute 'get'
   Template: l10n_ar_stock_ux.report_delivery_document
```

Con esta rama aplicada, misma base, mismo caso: `RESULTADO: renderiza OK`.

## El arreglo

`(o.l10n_ar_cai_data or {}).get('cai_authorization_code')` — normaliza antes de leer la clave. Aguanta los tres casos: sin datos (`False`), dict parcial y dict completo. El bloque de *CAI Due Date* colgado de `l10n_ar_cai_expiration_date` viene de #319 y está bien, se conserva tal cual.

## Y el problema de fondo, que #319 no tocaba

El `.get()` hacía falta porque el dict puede no traer la clave, y eso pasa con los remitos preimpresos: no tienen CAI porque viene impreso en el papel de la imprenta. Ese mismo patrón sin guard sigue vivo en el comprobante de **lote**, donde además `pre_printed_report` está fijo en `False`, así que rompe siempre:

```
QWebError: Error while rendering the template:
    KeyError: 'cai_authorization_code'
    Template: l10n_ar_stock_picking_batch.report_batch_delivery_document
    Element: <span t-out="o.l10n_ar_cai_data['cai_authorization_code']"/>
```

Va con el mismo criterio que el de la transferencia.

Esto hace falta **aunque** se arregle quien escribe el dato (eso va en el PR de seguimiento del módulo preimpreso): los remitos ya numerados con la primera versión del módulo tienen el dict parcial guardado en la base, y ningún cambio del productor los toca. Hay un test específico para esos registros.

## Alcance

Solo el pie de los dos comprobantes. Con el CAI completo el reporte sale exactamente igual que antes — hay un test que lo fija.

## Tests

Seis tests nuevos, tres por comprobante: sin datos de CAI (`False`), con el dict completo pero el código en blanco (remito preimpreso), y con el dict parcial que quedó en base. Más el caso de CAI completo, que verifica que el reporte lo sigue imprimiendo.

Verificado sobre `19.0` de hoy (con #319 ya adentro) y con `l10n_ar_stock_preprinted` sin instalar, que es como está la rama: `0 failed, 0 error(s) of 18 tests`, incluidos los 10 de #312.

Contra el código actual de `19.0`, los tests de regresión fallan así:

```
ERROR: TestL10nArStockUxDeliveryReport.test_renders_without_cai_data
       AttributeError: 'bool' object has no attribute 'get'
ERROR: TestL10nArBatchDeliveryReport.test_renders_with_partial_cai_data
       KeyError: 'cai_authorization_code'
FAIL:  TestL10nArBatchDeliveryReport.test_renders_with_cai_data_without_authorization_code
```

No depende de #318: se puede mezclar solo, y cuanto antes mejor.
