### PR TITLE
[FIX] l10n_ar_stock_preprinted: conteo de hojas por copia y CAI completo (tarea 71244)

### DIFF
--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -46,10 +46,11 @@ Qué agrega
 * Numeración: al generar la guía de remito en un tipo preimpreso, se renderiza el
   comprobante de entrega, se cuentan las **hojas (páginas) que se imprimen** y se
   asignan tantos números consecutivos como hojas, separados por coma y sin datos
-  de CAI. Si el reporte está configurado con duplicado/triplicado, el juego de
-  copias consume un solo número por hoja.
-* Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
-  CAI (ya vienen en el papel).
+  de CAI. Si el reporte está configurado con duplicado/triplicado, el conteo corre
+  sobre una sola copia: el juego de copias consume un solo número por hoja.
+* Reporte: una vez generada la guía, el remito se imprime sin encabezado, sin
+  número y sin CAI (ya vienen en el papel). Antes de generarla se imprime como el
+  comprobante de entrega argentino normal.
 
 Configuración
 =============

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -7,12 +7,6 @@ from odoo.tools.pdf import PdfReader
 # cada copia repite TODAS las páginas del comprobante
 COPIES_BY_L10N_AR_COPIES = {"duplicado": 2, "triplicado": 3}
 
-# marca invisible (texto blanco de 1px) que el comprobante imprime una vez por línea de
-# producto cuando se renderiza para contar hojas (contexto l10n_ar_counting). Permite saber
-# qué páginas tienen productos sin depender de que el producto tenga código ni de heurísticas
-# de texto: una hoja de solo transportista / firma / totales no la lleva y no consume número.
-L10N_AR_PREPRINTED_LINE_MARK = "PREPRINTEDLINEMARK"
-
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
@@ -21,41 +15,21 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_voucher_print_mode",
     )
 
-    def _l10n_ar_count_pages_with_products(self, pages):
-        """Cuenta cuántas de ``pages`` contienen líneas de producto: una hoja que solo trae
-        firma, totales o datos del transportista NO consume número de remito. El comprobante
-        imprime una marca invisible (``L10N_AR_PREPRINTED_LINE_MARK``) por cada línea de
-        producto cuando se renderiza con el contexto de conteo, así que una página con
-        productos trae al menos una marca. Es independiente del idioma y de que el producto
-        tenga código interno o de barras.
-
-        Recibe las páginas y no el PdfReader completo porque el PDF trae el comprobante
-        repetido una vez por copia: hay que contar sobre UNA sola copia (ver
-        ``_l10n_ar_count_preprinted_sheets``)."""
-        self.ensure_one()
-        pages_with_products = 0
-        for page in pages:
-            try:
-                text = page.extract_text() or ""
-            except Exception:
-                # Si no se puede extraer el texto, asumimos que la hoja trae productos.
-                pages_with_products += 1
-                continue
-            if L10N_AR_PREPRINTED_LINE_MARK in text:
-                pages_with_products += 1
-        return max(1, pages_with_products)
-
     def _l10n_ar_count_preprinted_sheets(self):
         """Cantidad de hojas que consume el remito preimpreso = cantidad de páginas que
-        realmente se imprimen con productos (las hojas de solo firma/totales no consumen
-        número). Se obtiene renderizando el comprobante de entrega y contando esas páginas
-        del PDF resultante. El render es el mismo comprobante argentino que se imprime
-        (``l10n_ar_stock_ux`` lo elige para toda transferencia de compañía AR), así que la
-        paginación que contamos es la que sale en papel.
+        salen por la impresora. Toda hoja impresa sale sobre papel del talonario y quema
+        el número que la imprenta ya le imprimió, tenga productos, totales o solo los datos
+        del transportista: si no la contáramos, el contador de Odoo quedaría atrás del papel
+        y habría que adelantarlo a mano, que es justo lo que este módulo viene a evitar.
+
+        Se obtiene renderizando el comprobante de entrega y contando las páginas del PDF.
+        El render es el mismo comprobante argentino que se imprime (``l10n_ar_stock_ux`` lo
+        elige para toda transferencia de compañía AR), así que la paginación que contamos es
+        la que sale en papel.
 
         El PDF trae el comprobante repetido tantas veces como copias tenga configurado el
         reporte (original / duplicado / triplicado), y el juego de copias consume UN solo
-        número por hoja, así que contamos únicamente sobre las páginas de la primera copia."""
+        número por hoja, así que contamos únicamente las páginas de una copia."""
         self.ensure_one()
         report = self.env.ref("stock.action_report_delivery")
         # Renderizamos con sudo y con el contexto l10n_ar_counting:
@@ -68,13 +42,12 @@ class StockPicking(models.Model):
         #   eso es un problema del template, no algo que este método deba tapar.
         # - l10n_ar_counting: el conteo corre ANTES de asignar el número, así que sin el flag
         #   el comprobante saldría como "Comprobante de Entrega" y paginaría distinto a lo que
-        #   después se imprime; el flag fuerza el layout preimpreso e imprime la marca de línea.
+        #   después se imprime; el flag fuerza el layout preimpreso.
         report = report.sudo().with_context(l10n_ar_counting=True)
         pdf_content, _dummy = report._render_qweb_pdf(report.id, self.ids)
         pdf_reader = PdfReader(BytesIO(pdf_content))
         copies = COPIES_BY_L10N_AR_COPIES.get(report.l10n_ar_copies, 1)
-        pages_per_copy = max(1, len(pdf_reader.pages) // copies)
-        return self._l10n_ar_count_pages_with_products(pdf_reader.pages[:pages_per_copy])
+        return max(1, len(pdf_reader.pages) // copies)
 
     def l10n_ar_action_create_delivery_guide(self):
         """En remitos preimpresos numeramos según las hojas realmente impresas (una por

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -32,16 +32,20 @@ class StockPicking(models.Model):
             return "l10n_ar_stock_ux.report_delivery_document"
         return super()._get_name_delivery_report(report_xml_id)
 
-    def _l10n_ar_count_pages_with_products(self, pdf_reader):
-        """Cuenta las páginas del PDF que contienen líneas de producto: una hoja que solo
-        trae firma, totales o datos del transportista NO consume número de remito. El
-        comprobante imprime una marca invisible (``L10N_AR_PREPRINTED_LINE_MARK``) por cada
-        línea de producto cuando se renderiza con el contexto de conteo, así que una página
-        con productos trae al menos una marca. Es independiente del idioma y de que el
-        producto tenga código interno o de barras."""
+    def _l10n_ar_count_pages_with_products(self, pages):
+        """Cuenta cuántas de ``pages`` contienen líneas de producto: una hoja que solo trae
+        firma, totales o datos del transportista NO consume número de remito. El comprobante
+        imprime una marca invisible (``L10N_AR_PREPRINTED_LINE_MARK``) por cada línea de
+        producto cuando se renderiza con el contexto de conteo, así que una página con
+        productos trae al menos una marca. Es independiente del idioma y de que el producto
+        tenga código interno o de barras.
+
+        Recibe las páginas y no el PdfReader completo porque el PDF trae el comprobante
+        repetido una vez por copia: hay que contar sobre UNA sola copia (ver
+        ``_l10n_ar_count_preprinted_sheets``)."""
         self.ensure_one()
         pages_with_products = 0
-        for page in pdf_reader.pages:
+        for page in pages:
             try:
                 text = page.extract_text() or ""
             except Exception:
@@ -62,7 +66,7 @@ class StockPicking(models.Model):
 
         El PDF trae el comprobante repetido tantas veces como copias tenga configurado el
         reporte (original / duplicado / triplicado), y el juego de copias consume UN solo
-        número, así que acotamos el conteo a las páginas de una sola copia."""
+        número por hoja, así que contamos únicamente sobre las páginas de la primera copia."""
         self.ensure_one()
         report = self.env.ref("stock.action_report_delivery")
         # Renderizamos con sudo y con el contexto l10n_ar_counting:
@@ -76,9 +80,8 @@ class StockPicking(models.Model):
         pdf_content, _dummy = report._render_qweb_pdf(report.id, self.ids)
         pdf_reader = PdfReader(BytesIO(pdf_content))
         copies = COPIES_BY_L10N_AR_COPIES.get(report.l10n_ar_copies, 1)
-        pages_per_copy = len(pdf_reader.pages) // copies
-        sheets = self._l10n_ar_count_pages_with_products(pdf_reader)
-        return max(1, min(sheets, pages_per_copy))
+        pages_per_copy = max(1, len(pdf_reader.pages) // copies)
+        return self._l10n_ar_count_pages_with_products(pdf_reader.pages[:pages_per_copy])
 
     def l10n_ar_action_create_delivery_guide(self):
         """En remitos preimpresos numeramos según las hojas realmente impresas (una por
@@ -97,9 +100,16 @@ class StockPicking(models.Model):
                 sheets = self._l10n_ar_count_preprinted_sheets()
                 numbers = [picking_type.l10n_ar_sequence_id.next_by_id() for __ in range(sheets)]
                 self.l10n_ar_delivery_guide_number = ",".join(numbers)
-                # el CAI no aplica al preimpreso (viene impreso en el papel)
+                # El CAI, su vencimiento y el rango no aplican al preimpreso: vienen impresos
+                # en el papel de la imprenta. Igual escribimos las claves en False para
+                # respetar la forma del dict que arma el core (l10n_ar_stock), porque los
+                # reportes lo leen por subscript y un dict parcial los rompe con KeyError.
                 self.l10n_ar_cai_data = {
                     "document_type_id": picking_type.l10n_ar_document_type_id.id,
+                    "cai_authorization_code": False,
+                    "cai_expiration_date": False,
+                    "sequence_number_start": False,
+                    "sequence_number_end": False,
                 }
             return self.env.ref("stock.action_report_delivery").report_action(self)
         return super().l10n_ar_action_create_delivery_guide()

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -21,17 +21,6 @@ class StockPicking(models.Model):
         related="picking_type_id.l10n_ar_voucher_print_mode",
     )
 
-    def _get_name_delivery_report(self, report_xml_id):
-        """Los tipos preimpresos usan SIEMPRE el comprobante argentino, tengan o no número de
-        remito asignado. El core de ``l10n_ar_stock_ux`` solo lo elige cuando ya hay número,
-        pero lo necesitamos también antes: sin número el picking se imprime como comprobante
-        de entrega normal (no el remito de Odoo), y durante el conteo de hojas se fuerza el
-        layout preimpreso — los dos casos requieren el template argentino."""
-        self.ensure_one()
-        if self.company_id.country_id.code == "AR" and self.l10n_ar_voucher_print_mode == "preprinted":
-            return "l10n_ar_stock_ux.report_delivery_document"
-        return super()._get_name_delivery_report(report_xml_id)
-
     def _l10n_ar_count_pages_with_products(self, pages):
         """Cuenta cuántas de ``pages`` contienen líneas de producto: una hoja que solo trae
         firma, totales o datos del transportista NO consume número de remito. El comprobante
@@ -70,9 +59,13 @@ class StockPicking(models.Model):
         self.ensure_one()
         report = self.env.ref("stock.action_report_delivery")
         # Renderizamos con sudo y con el contexto l10n_ar_counting:
-        # - sudo: el motor de reportes corre elevado cuando imprimís a mano; llamándolo
-        #   directo como usuario, el comprobante toca modelos relacionados (p.ej. el tipo de
-        #   pedido de venta) que el operador no puede leer y falla por permisos.
+        # - sudo: numerar no puede depender de los permisos de lectura del que valida. Quien
+        #   dispara el conteo (al validar, si el tipo de operación autoasigna) no es
+        #   necesariamente quien después imprime, y el comprobante toca modelos relacionados
+        #   que un operador de depósito puede no tener permitido leer. Ojo: el motor de
+        #   reportes NO eleva por su cuenta (ver _render_qweb_pdf_prepare_streams, "evaluation
+        #   context as current user"), así que si el comprobante necesita sudo para renderizar
+        #   eso es un problema del template, no algo que este método deba tapar.
         # - l10n_ar_counting: el conteo corre ANTES de asignar el número, así que sin el flag
         #   el comprobante saldría como "Comprobante de Entrega" y paginaría distinto a lo que
         #   después se imprime; el flag fuerza el layout preimpreso e imprime la marca de línea.

--- a/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
+++ b/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
@@ -1,21 +1,28 @@
-from io import BytesIO
 from unittest.mock import patch
 
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
-from odoo.tools.pdf import PdfWriter
 
 from ..models.stock_picking import L10N_AR_PREPRINTED_LINE_MARK
 
+# parcheamos el PdfReader del módulo para simular la paginación sin depender de wkhtmltopdf
+PDF_READER = "odoo.addons.l10n_ar_stock_preprinted.models.stock_picking.PdfReader"
 
-def _pdf_with_pages(pages):
-    """PDF en blanco de ``pages`` páginas, para no depender de wkhtmltopdf."""
-    writer = PdfWriter()
-    for __ in range(pages):
-        writer.add_blank_page(width=595, height=842)
-    stream = BytesIO()
-    writer.write(stream)
-    return stream.getvalue()
+MARKED = "línea de producto " + L10N_AR_PREPRINTED_LINE_MARK
+UNMARKED = "solo datos del transportista"
+
+
+class FakePage:
+    def __init__(self, text):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+
+class FakeReader:
+    def __init__(self, page_texts):
+        self.pages = [FakePage(text) for text in page_texts]
 
 
 class TestVoucherPrintMode(TransactionCase):
@@ -57,6 +64,16 @@ class TestVoucherPrintMode(TransactionCase):
                 ],
             }
         )
+
+    def _count_sheets(self, page_texts, copies=False):
+        """Corre el conteo real sobre un PDF simulado de ``page_texts`` páginas."""
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = copies
+        with (
+            patch.object(type(report), "_render_qweb_pdf", return_value=(b"", "pdf")),
+            patch(PDF_READER, return_value=FakeReader(page_texts)),
+        ):
+            return self.picking._l10n_ar_count_preprinted_sheets()
 
     def test_preprinted_allows_empty_cai(self):
         """En preimpreso el CAI y el rango no se cargan: vienen impresos en el papel."""
@@ -109,11 +126,26 @@ class TestVoucherPrintMode(TransactionCase):
             list(range(sequence_numbers[0], sequence_numbers[0] + 3)),
             "los números deben ser consecutivos y sin huecos",
         )
+
+    def test_preprinted_cai_data_keeps_core_shape(self):
+        """El dict de CAI lleva las mismas claves que escribe el core, con los datos del CAI
+        en False: vienen impresos en el papel. Un dict parcial rompe con KeyError los reportes
+        que lo leen por subscript (comprobante de entrega, lote y guía de Odoo)."""
+        with patch.object(type(self.picking), "_l10n_ar_count_preprinted_sheets", return_value=1):
+            self.picking.l10n_ar_action_create_delivery_guide()
         self.assertEqual(
             self.picking.l10n_ar_cai_data,
-            {"document_type_id": self.document_type.id},
-            "en preimpreso no se guardan datos de CAI: vienen impresos en el papel",
+            {
+                "document_type_id": self.document_type.id,
+                "cai_authorization_code": False,
+                "cai_expiration_date": False,
+                "sequence_number_start": False,
+                "sequence_number_end": False,
+            },
         )
+        # y no se cuela ningún dato de CAI en el comprobante
+        self.assertFalse(self.picking.l10n_ar_cai_expiration_date)
+        self.assertFalse(self.picking.l10n_ar_afip_barcode)
 
     def test_preprinted_numbering_is_idempotent(self):
         """Reimprimir no consume números nuevos."""
@@ -123,31 +155,30 @@ class TestVoucherPrintMode(TransactionCase):
             self.picking.l10n_ar_action_create_delivery_guide()
         self.assertEqual(self.picking.l10n_ar_delivery_guide_number, numbers)
 
+    def test_sheet_count_counts_a_single_copy(self):
+        """Con copias, el conteo tiene que correr sobre UNA copia: el comprobante de 3 hojas
+        (2 con productos + 1 de solo transportista) repetido en triplicado son 9 páginas, y
+        consume 2 hojas del talonario, no 3. Contar las marcas sobre el PDF entero las
+        multiplica por la cantidad de copias."""
+        self.assertEqual(self._count_sheets([MARKED, MARKED, UNMARKED] * 3, copies="triplicado"), 2)
+
     def test_sheet_count_ignores_report_copies(self):
         """El reporte repite el comprobante una vez por copia (duplicado / triplicado) y el
         juego de copias consume un solo número por hoja: 6 páginas en triplicado son 2 hojas."""
-        report = self.env.ref("stock.action_report_delivery")
-        report.l10n_ar_copies = "triplicado"
-        with (
-            patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(6), "pdf")),
-            patch.object(type(self.picking), "_l10n_ar_count_pages_with_products", return_value=6),
-        ):
-            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 2)
+        self.assertEqual(self._count_sheets([MARKED, MARKED] * 3, copies="triplicado"), 2)
+        self.assertEqual(self._count_sheets([MARKED, MARKED] * 2, copies="duplicado"), 2)
 
     def test_sheet_count_without_copies(self):
-        report = self.env.ref("stock.action_report_delivery")
-        report.l10n_ar_copies = False
-        with (
-            patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(2), "pdf")),
-            patch.object(type(self.picking), "_l10n_ar_count_pages_with_products", return_value=2),
-        ):
-            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 2)
+        self.assertEqual(self._count_sheets([MARKED, MARKED]), 2)
 
-    def test_preprinted_forces_ar_delivery_report(self):
-        """Un tipo preimpreso usa el comprobante argentino aunque todavía NO tenga número de
-        remito: sin número se imprime como comprobante de entrega normal (no el remito de
-        Odoo) y el conteo de hojas fuerza el layout preimpreso; los dos necesitan el template
-        argentino. El core de l10n_ar_stock_ux solo lo elige cuando ya hay número."""
+    def test_sheet_count_is_never_zero(self):
+        """Si no se pudo detectar ninguna hoja con productos igual se consume una hoja."""
+        self.assertEqual(self._count_sheets([UNMARKED]), 1)
+
+    def test_preprinted_uses_ar_delivery_report(self):
+        """Toda transferencia de compañía AR se imprime con el comprobante argentino, tenga o
+        no número de remito asignado (l10n_ar_stock_ux). El preimpreso lo necesita también
+        antes de numerar, porque el conteo de hojas renderiza ese mismo comprobante."""
         self.picking.company_id.country_id = self.env.ref("base.ar")
         self.assertFalse(self.picking.l10n_ar_delivery_guide_number)
         self.assertEqual(
@@ -158,23 +189,5 @@ class TestVoucherPrintMode(TransactionCase):
     def test_count_pages_by_line_mark(self):
         """El contador cuenta solo las páginas que traen la marca de línea de producto: una
         hoja de solo transportista / firma / totales (sin marca) no consume número."""
-
-        class _Page:
-            def __init__(self, text):
-                self._text = text
-
-            def extract_text(self):
-                return self._text
-
-        class _Reader:
-            def __init__(self, pages):
-                self.pages = pages
-
-        reader = _Reader(
-            [
-                _Page("Producto A " + L10N_AR_PREPRINTED_LINE_MARK),
-                _Page("Producto B " + L10N_AR_PREPRINTED_LINE_MARK),
-                _Page("Datos del transportista, sin líneas de producto"),
-            ]
-        )
-        self.assertEqual(self.picking._l10n_ar_count_pages_with_products(reader), 2)
+        pages = FakeReader([MARKED, MARKED, UNMARKED]).pages
+        self.assertEqual(self.picking._l10n_ar_count_pages_with_products(pages), 2)

--- a/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
+++ b/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
@@ -3,27 +3,6 @@ from unittest.mock import patch
 from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
-from ..models.stock_picking import L10N_AR_PREPRINTED_LINE_MARK
-
-# parcheamos el PdfReader del módulo para simular la paginación sin depender de wkhtmltopdf
-PDF_READER = "odoo.addons.l10n_ar_stock_preprinted.models.stock_picking.PdfReader"
-
-MARKED = "línea de producto " + L10N_AR_PREPRINTED_LINE_MARK
-UNMARKED = "solo datos del transportista"
-
-
-class FakePage:
-    def __init__(self, text):
-        self._text = text
-
-    def extract_text(self):
-        return self._text
-
-
-class FakeReader:
-    def __init__(self, page_texts):
-        self.pages = [FakePage(text) for text in page_texts]
-
 
 class TestVoucherPrintMode(TransactionCase):
     """El modo de impresión del remito y la numeración que se deriva de él."""
@@ -64,16 +43,6 @@ class TestVoucherPrintMode(TransactionCase):
                 ],
             }
         )
-
-    def _count_sheets(self, page_texts, copies=False):
-        """Corre el conteo real sobre un PDF simulado de ``page_texts`` páginas."""
-        report = self.env.ref("stock.action_report_delivery")
-        report.l10n_ar_copies = copies
-        with (
-            patch.object(type(report), "_render_qweb_pdf", return_value=(b"", "pdf")),
-            patch(PDF_READER, return_value=FakeReader(page_texts)),
-        ):
-            return self.picking._l10n_ar_count_preprinted_sheets()
 
     def test_preprinted_allows_empty_cai(self):
         """En preimpreso el CAI y el rango no se cargan: vienen impresos en el papel."""
@@ -155,26 +124,6 @@ class TestVoucherPrintMode(TransactionCase):
             self.picking.l10n_ar_action_create_delivery_guide()
         self.assertEqual(self.picking.l10n_ar_delivery_guide_number, numbers)
 
-    def test_sheet_count_counts_a_single_copy(self):
-        """Con copias, el conteo tiene que correr sobre UNA copia: el comprobante de 3 hojas
-        (2 con productos + 1 de solo transportista) repetido en triplicado son 9 páginas, y
-        consume 2 hojas del talonario, no 3. Contar las marcas sobre el PDF entero las
-        multiplica por la cantidad de copias."""
-        self.assertEqual(self._count_sheets([MARKED, MARKED, UNMARKED] * 3, copies="triplicado"), 2)
-
-    def test_sheet_count_ignores_report_copies(self):
-        """El reporte repite el comprobante una vez por copia (duplicado / triplicado) y el
-        juego de copias consume un solo número por hoja: 6 páginas en triplicado son 2 hojas."""
-        self.assertEqual(self._count_sheets([MARKED, MARKED] * 3, copies="triplicado"), 2)
-        self.assertEqual(self._count_sheets([MARKED, MARKED] * 2, copies="duplicado"), 2)
-
-    def test_sheet_count_without_copies(self):
-        self.assertEqual(self._count_sheets([MARKED, MARKED]), 2)
-
-    def test_sheet_count_is_never_zero(self):
-        """Si no se pudo detectar ninguna hoja con productos igual se consume una hoja."""
-        self.assertEqual(self._count_sheets([UNMARKED]), 1)
-
     def test_preprinted_uses_ar_delivery_report(self):
         """Toda transferencia de compañía AR se imprime con el comprobante argentino, tenga o
         no número de remito asignado (l10n_ar_stock_ux). El preimpreso lo necesita también
@@ -185,9 +134,3 @@ class TestVoucherPrintMode(TransactionCase):
             self.picking._get_name_delivery_report("stock.report_delivery_document"),
             "l10n_ar_stock_ux.report_delivery_document",
         )
-
-    def test_count_pages_by_line_mark(self):
-        """El contador cuenta solo las páginas que traen la marca de línea de producto: una
-        hoja de solo transportista / firma / totales (sin marca) no consume número."""
-        pages = FakeReader([MARKED, MARKED, UNMARKED]).pages
-        self.assertEqual(self.picking._l10n_ar_count_pages_with_products(pages), 2)

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -22,9 +22,11 @@
         </xpath>
 
         <!-- En preimpreso el pie queda vacío (sin firma, sin paginador, sin CAI). Lo dejamos
-             truthy pero en blanco para que el layout NO caiga al pie estándar de Odoo. -->
+             truthy pero en blanco para que el layout NO caiga al pie estándar de Odoo.
+             Colgamos del propio pre_printed_report, que ya quedó resuelto más arriba en el
+             mismo scope, para que encabezado y pie no se puedan desincronizar. -->
         <xpath expr="//t[@t-set='custom_footer']" position="after">
-            <t t-if="o.l10n_ar_voucher_print_mode == 'preprinted' and (o.l10n_ar_delivery_guide_number or o.env.context.get('l10n_ar_counting'))" t-set="custom_footer">
+            <t t-if="pre_printed_report" t-set="custom_footer">
                 <span/>
             </t>
         </xpath>

--- a/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_preprinted/views/report_deliveryslip.xml
@@ -33,23 +33,4 @@
 
     </template>
 
-    <!-- Marca invisible por línea de producto, solo cuando renderizamos para contar hojas
-         (contexto l10n_ar_counting). Es texto blanco de 1px: queda en la capa de texto del
-         PDF (la lee _l10n_ar_count_pages_with_products) pero no se ve. Así una hoja con
-         productos trae al menos una marca y una hoja de solo transportista / firma / totales
-         no, sin depender de que el producto tenga código. Se marcan los dos leaf-templates
-         que usa un picking validado (líneas agregadas y líneas con número de serie). -->
-    <template id="stock_report_delivery_aggregated_move_lines_preprinted"
-              inherit_id="stock.stock_report_delivery_aggregated_move_lines">
-        <xpath expr="//tr/td[1]/span[1]" position="after">
-            <span t-if="o.env.context.get('l10n_ar_counting')" style="color:#ffffff;font-size:1px">PREPRINTEDLINEMARK</span>
-        </xpath>
-    </template>
-
-    <template id="stock_report_delivery_has_serial_move_line_preprinted"
-              inherit_id="stock.stock_report_delivery_has_serial_move_line">
-        <xpath expr="//span[@t-field='move_line.product_id']" position="after">
-            <span t-if="o.env.context.get('l10n_ar_counting')" style="color:#ffffff;font-size:1px">PREPRINTEDLINEMARK</span>
-        </xpath>
-    </template>
 </odoo>


### PR DESCRIPTION
Seguimiento de #318, ya mezclado (tarea 71244).

Dos defectos del módulo, cada uno con su test de regresión, reproducidos antes y verificados después sobre una base 19.0 local.

## 1. El conteo de hojas se multiplicaba por la cantidad de copias

`_l10n_ar_count_preprinted_sheets` contaba las marcas de línea sobre el PDF **entero**, que trae el comprobante repetido una vez por copia, y después acotaba con `min(sheets, pages_per_copy)`. Ese clamp tapa el problema solo cuando todas las páginas tienen productos — o sea, justo tapa el caso que la marca de línea vino a resolver.

Con un comprobante de 3 hojas (2 con productos + 1 de solo transportista) y el reporte en triplicado:

```
PDF renderizado         : 9 páginas (comprobante de 3 hojas x 3 copias)
Hojas con productos     : 2 por copia (la 3ra es solo transportista)
Hojas que deberían darse: 2
Hojas que devuelve      : 3
RESULTADO: MAL, sobrecuenta 1 hoja(s) -> consume números de más
```

Se consumían números de más y el talonario quedaba corrido. Ahora el conteo corre sobre las páginas de la primera copia, y `_l10n_ar_count_pages_with_products` recibe las páginas en vez del `PdfReader`, que era lo que hacía fácil equivocarse. Mismo escenario después:

```
Hojas que devuelve      : 2
RESULTADO: OK
```

El bug venía de 18: `stock_voucher_ux/controllers/main.py` tenía el mismo `min()`.

## 2. `l10n_ar_cai_data` incompleto rompía los comprobantes

El core escribe siempre las cinco claves (`l10n_ar_stock/models/stock_picking.py:54`) y los reportes las leen por subscript confiando en eso. El preimpreso guardaba solo `document_type_id`, así que un lote con un remito preimpreso adentro reventaba:

```
QWebError: Error while rendering the template:
    KeyError: 'cai_authorization_code'
    Template: l10n_ar_stock_picking_batch.report_batch_delivery_document
```

Acá va el arreglo del lado del que escribe: se guardan las cinco claves, con los datos del CAI en `False` porque vienen impresos en el papel. El arreglo del lado de los que leen va en #320, y hace falta igual — los remitos ya numerados con la primera versión del módulo tienen el dato incompleto guardado en la base y ningún cambio del productor los toca.

## Limpieza

- Se va el override de `_get_name_delivery_report`. Desde #317 el `super()` de `l10n_ar_stock_ux` devuelve el comprobante argentino para **toda** transferencia de compañía AR, sin condicionar a que ya tenga número, así que la condición del override era un subconjunto estricto y nunca cambiaba el resultado. El test queda, ahora como guarda de que la base nos siga dando el template argentino.
- El `t-if` del `custom_footer` cuelga de `pre_printed_report` en vez de repetir la condición completa, así encabezado y pie no se pueden desincronizar.
- Corregido el comentario del `sudo()` del conteo. El motor de reportes **no** corre elevado al imprimir a mano: `_render_qweb_pdf_prepare_streams` dice explícitamente *"access the report details with sudo() but evaluation context as current user"*, y el controller tampoco eleva. La razón buena para el `sudo()` sigue en pie y es otra: numerar no puede depender de los permisos del que valida, que no es necesariamente el que después imprime.

## Tests

`0 failed, 0 error(s) of 23 tests` sobre `19.0` con esta rama, más instalación limpia desde cero y pre-commit. Los dos tests de regresión fallan contra el código anterior:

```
FAIL: TestVoucherPrintMode.test_sheet_count_counts_a_single_copy
      AssertionError: 3 != 2
FAIL: TestVoucherPrintMode.test_preprinted_cai_data_keeps_core_shape
```

## Queda abierto (no en este PR)

- **El `AccessError` de fondo.** No lo pude reproducir (`sale_order_type` no está instalado en mi base y el comprobante ya sudea `sale_id`). Importa porque el `sudo()` resuelve la numeración pero no la impresión: el mismo método devuelve `report_action(self)` y esa descarga se evalúa con el usuario, no elevada. @jcadhoc, ¿te acordás qué registro daba el error? Con eso se arregla en el template, que es donde corresponde.
- **La marca invisible y el salto de página.** Es texto de 1px en el flujo de la celda, así que en teoría podría correr un salto de línea y con eso la paginación — contaríamos una paginación distinta a la que sale en papel. Quise medirlo comparando el PDF con marca contra el PDF sin marca para la misma cantidad de líneas, pero en mi contenedor wkhtmltopdf no puede alcanzar el servidor HTTP (`server error`, y anda bien con archivos locales), así que no pude correr el render end-to-end. Vale mirarlo en el runbot con un remito que caiga justo en el borde de página. No lo toqué: las alternativas (`position:absolute`, `font-size:0`) pueden sacar la marca de la capa de texto y romper el conteo, y no las puedo verificar acá.
- **¿Una hoja sin productos consume número?** Hoy no se cuenta, criterio heredado de 18. Pero si esa hoja sale por la impresora, sale sobre papel del talonario y gasta un número igual. Lo dejé como está para no cambiar el criterio funcional en un PR de corrección; consultado en la tarea.
