### PR TITLE
[ADD] l10n_ar_sale_loyalty_delivery: keep VAT on free shipping reward

### DIFF
--- a/l10n_ar_sale_loyalty_delivery/README.rst
+++ b/l10n_ar_sale_loyalty_delivery/README.rst
@@ -1,0 +1,85 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=======================================================================
+Integración entre envío gratis de fidelización y localización argentina
+=======================================================================
+
+El módulo ``sale_loyalty_delivery`` arma la línea de recompensa de envío gratis heredando
+los impuestos de la línea de flete del pedido, porque asume que el envío gratis descuenta
+un flete ya cargado por un transportista.
+
+Cuando el envío gratis se usa como promoción (por ejemplo por dominio de provincia) sobre
+un pedido sin transportista, no hay línea de flete de la cual heredar el IVA: la línea de
+recompensa nace sin impuestos y la validación ``check_vat_tax`` de ``l10n_ar_sale`` la
+rechaza con el error "Debe haber un único impuesto del grupo de impuestos IVA por línea".
+
+Este módulo toma, en ese caso, el IVA del propio producto de la recompensa mapeado por la
+posición fiscal del pedido, tal como se obtendría agregando la línea a mano.
+
+#. Solo aplica a compañías argentinas que requieren IVA (Responsable Inscripto).
+#. La línea de recompensa nace en 0 igual que en el comportamiento estándar y se recalcula
+   al elegir el transportista, por lo que los importes del pedido no cambian.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only need to install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nothing to configure
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Crear un programa de fidelización con una recompensa de tipo "Envío gratis"
+#. Aplicarlo sobre un pedido de venta sin método de envío seleccionado
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/argentina-sale/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_sale_loyalty_delivery/__init__.py
+++ b/l10n_ar_sale_loyalty_delivery/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models

--- a/l10n_ar_sale_loyalty_delivery/__manifest__.py
+++ b/l10n_ar_sale_loyalty_delivery/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "Integración entre envío gratis de fidelización y localización argentina",
+    "version": "18.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "",
+    "depends": [
+        "l10n_ar_sale",
+        "sale_loyalty_delivery",
+    ],
+    "external_dependencies": {},
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/l10n_ar_sale_loyalty_delivery/models/__init__.py
+++ b/l10n_ar_sale_loyalty_delivery/models/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import sale_order

--- a/l10n_ar_sale_loyalty_delivery/models/sale_order.py
+++ b/l10n_ar_sale_loyalty_delivery/models/sale_order.py
@@ -1,0 +1,55 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+from odoo.fields import Command
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _l10n_ar_tax_ids_from_commands(self, commands):
+        """Devuelve los ids de impuestos que resultan de una lista de comandos x2many.
+
+        Resolvemos los comandos en lugar de buscar uno en particular para no depender de
+        cómo el estándar arma el valor de tax_id (hoy CLEAR + LINK, podría ser SET).
+        """
+        tax_ids = set()
+        for command in commands or []:
+            code = command[0]
+            if code == Command.SET:
+                tax_ids = set(command[2] or [])
+            elif code == Command.LINK:
+                tax_ids.add(command[1])
+            elif code == Command.UNLINK:
+                tax_ids.discard(command[1])
+            elif code == Command.CLEAR:
+                tax_ids.clear()
+        return tax_ids
+
+    def _get_reward_values_free_shipping(self, reward, coupon, **kwargs):
+        """El módulo sale_loyalty_delivery arma la línea de recompensa de envío gratis
+        heredando los impuestos de la línea de flete del pedido, porque asume que el envío
+        gratis descuenta un flete ya cargado por un transportista.
+
+        Cuando el envío gratis se usa como promoción (por ejemplo por dominio de provincia)
+        sobre un pedido sin transportista, no hay línea de flete de la cual heredar el IVA:
+        la línea de recompensa nace sin impuestos y check_vat_tax (l10n_ar_sale) la rechaza.
+
+        En ese caso tomamos el IVA del propio producto de la recompensa, tal como se
+        obtendría agregando la línea a mano, y si ese producto no tiene impuestos (loyalty
+        lo crea sin tomar los de la compañía) caemos al impuesto de venta por defecto de la
+        compañía. La línea nace en 0 igual que en el comportamiento estándar y se recalcula
+        cuando se elige el transportista, así que los importes del pedido no cambian.
+        """
+        res = super()._get_reward_values_free_shipping(reward, coupon, **kwargs)
+        if not (self.company_id.country_id == self.env.ref("base.ar") and self.company_id.l10n_ar_company_requires_vat):
+            return res
+        for vals in res:
+            if self._l10n_ar_tax_ids_from_commands(vals.get("tax_id")):
+                continue
+            taxes = reward.discount_line_product_id.taxes_id or self.company_id.account_sale_tax_id
+            taxes = self.fiscal_position_id.map_tax(taxes._filter_taxes_by_company(self.company_id))
+            vals["tax_id"] = [(Command.CLEAR, 0, 0)] + [(Command.LINK, tax.id, False) for tax in taxes]
+        return res

--- a/l10n_ar_sale_loyalty_delivery/tests/__init__.py
+++ b/l10n_ar_sale_loyalty_delivery/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_free_shipping_vat

--- a/l10n_ar_sale_loyalty_delivery/tests/test_free_shipping_vat.py
+++ b/l10n_ar_sale_loyalty_delivery/tests/test_free_shipping_vat.py
@@ -1,0 +1,144 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.fields import Command
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestFreeShippingVat(TestArCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.vat_21 = cls.env["account.tax"].search(
+            [
+                ("company_id", "=", cls.company_ri.id),
+                ("type_tax_use", "=", "sale"),
+                ("tax_group_id.l10n_ar_vat_afip_code", "=", "5"),
+            ],
+            limit=1,
+        )
+        assert cls.vat_21, "No se encontró el IVA 21% de venta de la compañía de prueba"
+
+        cls.delivery_product = cls.env["product.product"].create(
+            {
+                "name": "Flete",
+                "type": "service",
+                "categ_id": cls.env.ref("delivery.product_category_deliveries").id,
+                "sale_ok": False,
+                "purchase_ok": False,
+                "list_price": 100.0,
+                "taxes_id": [Command.set(cls.vat_21.ids)],
+            }
+        )
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Flete",
+                "fixed_price": 100.0,
+                "delivery_type": "fixed",
+                "product_id": cls.delivery_product.id,
+            }
+        )
+        cls.program = cls.env["loyalty.program"].create(
+            {
+                "name": "Envío gratis",
+                "program_type": "promotion",
+                "trigger": "auto",
+                "applies_on": "current",
+                "rule_ids": [Command.create({"minimum_amount": 0.0})],
+                "reward_ids": [Command.create({"reward_type": "shipping"})],
+            }
+        )
+        cls.reward = cls.program.reward_ids
+        # el producto de la recompensa lo crea loyalty tomando los impuestos por defecto de
+        # la compañía; lo fijamos para no depender de esa configuración en el test
+        cls.reward.discount_line_product_id.taxes_id = [Command.set(cls.vat_21.ids)]
+
+    def _new_order(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.res_partner_adhoc.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product_iva_21.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 1000.0,
+                            "tax_id": [Command.set(self.vat_21.ids)],
+                        }
+                    )
+                ],
+            }
+        )
+        order._update_programs_and_rewards()
+        return order
+
+    def _claim_free_shipping(self, order):
+        coupon = order.coupon_point_ids.coupon_id.filtered(lambda c: c.program_id == self.program)
+        self.assertEqual(len(coupon), 1, "El programa de envío gratis debería aplicarse al pedido")
+        status = order._apply_program_reward(self.reward, coupon)
+        self.assertNotIn("error", status, "No se pudo reclamar la recompensa: %s" % status)
+        return order.order_line.filtered(lambda line: line.reward_id.reward_type == "shipping")
+
+    def _vat_taxes(self, line):
+        return line.tax_id.filtered(lambda tax: tax.tax_group_id.l10n_ar_vat_afip_code)
+
+    def test_free_shipping_without_delivery_line(self):
+        """Sin línea de flete, la recompensa debe nacer con un único IVA y sin bloquear el pedido."""
+        order = self._new_order()
+        reward_line = self._claim_free_shipping(order)
+
+        self.assertTrue(reward_line, "Debería haberse agregado la línea de recompensa de envío gratis")
+        self.assertEqual(len(self._vat_taxes(reward_line)), 1)
+        self.assertEqual(reward_line.price_unit, 0.0, "Sin flete la recompensa vale 0, igual que en el estándar")
+        self.assertEqual(reward_line.price_total, 0.0, "El IVA sobre base 0 no debe alterar importes")
+
+    def test_free_shipping_with_delivery_line(self):
+        """Con línea de flete se mantiene el comportamiento estándar: hereda el IVA del flete."""
+        order = self._new_order()
+        order.set_delivery_line(self.carrier, self.carrier.fixed_price)
+        reward_line = self._claim_free_shipping(order)
+
+        delivery_line = order.order_line.filtered("is_delivery")
+        self.assertEqual(reward_line.tax_id, delivery_line.tax_id)
+        self.assertEqual(reward_line.price_unit, -delivery_line.price_unit)
+
+    def test_tax_ids_from_commands(self):
+        """Los comandos x2many se resuelven a ids, sin depender de cómo los arme el estándar."""
+        resolve = self.env["sale.order"]._l10n_ar_tax_ids_from_commands
+
+        self.assertFalse(resolve(None))
+        self.assertFalse(resolve([]))
+        self.assertFalse(resolve([(Command.CLEAR, 0, 0)]))
+        # forma que usa hoy sale_loyalty_delivery
+        self.assertEqual(resolve([(Command.CLEAR, 0, 0), (Command.LINK, 7, False)]), {7})
+        # forma alternativa: un único SET, que no trae ningún LINK
+        self.assertEqual(resolve([Command.set([7, 9])]), {7, 9})
+        # un SET posterior reemplaza lo anterior; UNLINK descuenta
+        self.assertEqual(resolve([Command.link(9), Command.set([7])]), {7})
+        self.assertFalse(resolve([Command.link(7), Command.unlink(7)]))
+
+    def test_free_shipping_without_taxes_on_reward_product(self):
+        """Si el producto de la recompensa no tiene impuestos, se usa el de venta de la compañía."""
+        self.reward.discount_line_product_id.taxes_id = [Command.clear()]
+        self.company_ri.account_sale_tax_id = self.vat_21
+
+        order = self._new_order()
+        reward_line = self._claim_free_shipping(order)
+
+        self.assertEqual(self._vat_taxes(reward_line), self.vat_21)
+
+    def test_free_shipping_after_removing_delivery_line(self):
+        """Al quitar el transportista la recompensa se recalcula y no debe quedar sin IVA."""
+        order = self._new_order()
+        order.set_delivery_line(self.carrier, self.carrier.fixed_price)
+        self._claim_free_shipping(order)
+
+        order._remove_delivery_line()
+        order._update_programs_and_rewards()
+
+        reward_line = order.order_line.filtered(lambda line: line.reward_id.reward_type == "shipping")
+        self.assertEqual(len(self._vat_taxes(reward_line)), 1)


### PR DESCRIPTION
sale_loyalty_delivery arma la línea de recompensa de envío gratis heredando los impuestos de la línea de flete del pedido, porque asume que el envío gratis descuenta un flete ya cargado por un transportista.

Cuando la recompensa se usa como promoción (por ejemplo por dominio de provincia) sobre un pedido sin transportista no hay línea de flete de la cual heredar el IVA: la línea de recompensa se crea sin impuestos y check_vat_tax (l10n_ar_sale) rechaza toda la operación con "Debe haber un único impuesto del grupo de impuestos IVA por línea".

Tomamos el IVA del propio producto de la recompensa, y si ese producto no tiene impuestos caemos al impuesto de venta de la compañía, mapeado por la posición fiscal del pedido. La línea se sigue creando con precio 0 igual que en el comportamiento estándar y se recalcula al elegir el transportista, así que los importes del pedido no cambian.