### PR TITLE
[FIX] l10n_ar_stock_ux: guard empty CAI data on delivery report

### DIFF
--- a/l10n_ar_stock_ux/views/report_deliveryslip.xml
+++ b/l10n_ar_stock_ux/views/report_deliveryslip.xml
@@ -83,7 +83,7 @@
                     </div>
 
                     <div name="footer_right_column" class="col-4 text-right">
-                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data.get('cai_authorization_code')">
+                        <div t-if="not pre_printed_report and o.l10n_ar_cai_data and o.l10n_ar_cai_data.get('cai_authorization_code')">
                             CAI: <span t-out="o.l10n_ar_cai_data.get('cai_authorization_code')"/>
                         </div>
                         <div t-if="not pre_printed_report and o.l10n_ar_cai_expiration_date">


### PR DESCRIPTION
El reporte de remito evalúa `o.l10n_ar_cai_data.get('cai_authorization_code')` en el `t-if`. `l10n_ar_cai_data` es un `fields.Json`: cuando no hay CAI guardado vale `False`, así que el `.get()` termina en `AttributeError: 'bool' object has no attribute 'get'` y el PDF no se genera. Afecta a cualquier remito sin CAI, que es el caso más común.

Es una regresión de #319: al pasar de subscript a `.get()` se perdió el guard de truthy. Este PR lo repone. El caso que arreglaba #319 (dict de CAI parcial, sin la clave del código) sigue cubierto por el `.get()`.

## Test plan

Renderizando el reporte de remito en los tres escenarios:

- Sin CAI (`l10n_ar_cai_data` vacío) → el reporte se genera y no imprime el bloque CAI. Sin este fix reproduce el `AttributeError`.
- Con CAI parcial (`{"document_type_id": N}`, lo que guarda el preimpreso) → se genera, sin bloque CAI.
- Con CAI completo → imprime el código de autorización.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124980
