### PR TITLE
[FIX] l10n_ar_stock_ux: assign delivery guide number at end of validation

### DIFF
--- a/l10n_ar_stock_ux/models/stock_picking.py
+++ b/l10n_ar_stock_ux/models/stock_picking.py
@@ -505,14 +505,30 @@ class StockPicking(models.Model):
 
             return True
 
+    def _l10n_ar_assign_delivery_guide_numbers(self):
+        for picking in self.filtered(
+            lambda p: p.picking_type_id.auto_assign_delivery_guide and not p.l10n_ar_delivery_guide_number
+        ):
+            picking.l10n_ar_action_create_delivery_guide()
+
+    def _send_confirmation_email(self):
+        # asignamos el nro recién acá — el hook que stock llama al final de _action_done,
+        # justo antes de mandar el mail de confirmación — para que el reporte que adjunta
+        # el mail salga con look y nro argentino sin tomar el lock temprano (ver
+        # _action_done)
+        self._l10n_ar_assign_delivery_guide_numbers()
+        return super()._send_confirmation_email()
+
     def _action_done(self):
-        # asignamos nro antes de validar para que el reporte que salga al enviar por correo (_send_confirmation_email)
-        # sea con look y nro argentino
-        # TODO revisar si alguien lo usa y sacar este contexto
-        if not self._context.get("do_not_assign_numbers", False):
-            for picking in self.filtered("picking_type_id.auto_assign_delivery_guide"):
-                picking.l10n_ar_action_create_delivery_guide()
+        # next_by_id() sobre la secuencia no_gap del remito toma un lock de fila sobre
+        # ir_sequence (SELECT ... FOR UPDATE NOWAIT) que se retiene hasta el commit:
+        # asignar el nro al inicio de la validación serializa las validaciones
+        # concurrentes contra toda la duración de _action_done (valuación, backorders,
+        # mails) y produce LockNotAvailable en validaciones masivas. Por eso se asigna
+        # lo más tarde posible: en _send_confirmation_email, y acá solo como catch-all
+        # por si algún flujo no pasa por ese hook.
         res = super()._action_done()
+        self._l10n_ar_assign_delivery_guide_numbers()
         for rec in self.filtered(lambda x: x.picking_type_code == "incoming" and x.dispatch_number):
             rec.move_line_ids.filtered(lambda l: l.lot_id and not l.lot_id.dispatch_number).mapped("lot_id").write(
                 {"dispatch_number": rec.dispatch_number}

--- a/l10n_ar_stock_ux/tests/__init__.py
+++ b/l10n_ar_stock_ux/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_auto_assign_delivery_guide
 from . import test_report_delivery
 from . import test_stock_picking_type

--- a/l10n_ar_stock_ux/tests/test_auto_assign_delivery_guide.py
+++ b/l10n_ar_stock_ux/tests/test_auto_assign_delivery_guide.py
@@ -1,0 +1,96 @@
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.addons.l10n_ar_stock.models.stock_picking import StockPicking as L10nArStockPicking
+from odoo.addons.stock.models.stock_picking import StockPicking as StockStockPicking
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestAutoAssignDeliveryGuide(TestArCommon):
+    """Ticket #125173: la asignación automática del nro de remito consume una secuencia
+    no_gap (lock de fila sobre ir_sequence hasta el commit), por lo que debe hacerse al
+    final de la validación — con el picking ya en done — y no antes de _action_done.
+    Cuando la compañía envía el mail de confirmación, el nro debe estar asignado al
+    momento del envío para que el reporte adjunto salga con el nro argentino."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.wh = cls.env["stock.warehouse"].search([("company_id", "=", cls.company_ri.id)], limit=1)
+        cls.product = cls.env["product.product"].create({"name": "Test Product"})
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito Outgoing Auto",
+                "code": "outgoing",
+                "company_id": cls.company_ri.id,
+                "sequence_code": "OUTAUTO",
+                "auto_assign_delivery_guide": True,
+                "l10n_ar_document_type_id": cls.env.ref("l10n_ar.dc_r_r").id,
+                "l10n_ar_cai_authorization_code": "99999999999999",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "99999999",
+            }
+        )
+
+    def _create_picking(self):
+        picking = self.env["stock.picking"].create(
+            {
+                "location_id": self.wh.lot_stock_id.id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "picking_type_id": self.picking_type.id,
+                "partner_id": self.partner_ri.id,
+                "move_ids": [Command.create({"product_id": self.product.id, "product_uom_qty": 1.0})],
+            }
+        )
+        picking.action_confirm()
+        return picking
+
+    def _validate_recording_states(self, picking):
+        """Valida el picking espiando en qué estado estaba al asignársele el nro de remito."""
+        states = []
+        original = L10nArStockPicking.l10n_ar_action_create_delivery_guide
+
+        def _spy(record):
+            states.append(record.state)
+            return original(record)
+
+        with patch.object(L10nArStockPicking, "l10n_ar_action_create_delivery_guide", _spy):
+            picking.button_validate()
+        return states
+
+    def test_assign_after_done_without_confirmation_email(self):
+        """Sin mail de confirmación el nro se asigna con el picking ya validado,
+        minimizando la ventana del lock de la secuencia no_gap."""
+        self.company_ri.stock_move_email_validation = False
+        picking = self._create_picking()
+        states = self._validate_recording_states(picking)
+        self.assertTrue(picking.l10n_ar_delivery_guide_number, "El nro de remito debe asignarse igual.")
+        self.assertEqual(states, ["done"], "El nro debe asignarse al final de la validación, no antes.")
+
+    def test_number_available_when_confirmation_email_is_sent(self):
+        """Con mail de confirmación activo, el nro ya debe estar asignado al momento del
+        envío (el reporte que adjunta el mail lo embebe), sin adelantar la asignación al
+        inicio de la validación."""
+        self.company_ri.stock_move_email_validation = True
+        picking = self._create_picking()
+        numbers_at_send = []
+
+        # espiamos el hook nativo (el super() de nuestro override): registra qué nro
+        # tenía el picking al momento del envío y neutraliza el envío real, que es
+        # comportamiento de stock y no lo que se prueba acá
+        def _spy_send(record):
+            numbers_at_send.extend(record.mapped("l10n_ar_delivery_guide_number"))
+
+        with patch.object(StockStockPicking, "_send_confirmation_email", _spy_send):
+            states = self._validate_recording_states(picking)
+
+        self.assertTrue(picking.l10n_ar_delivery_guide_number, "El nro de remito debe asignarse igual.")
+        self.assertEqual(states, ["done"], "El nro debe asignarse al final de la validación, no antes.")
+        self.assertEqual(
+            numbers_at_send,
+            [picking.l10n_ar_delivery_guide_number],
+            "El nro ya debe estar asignado cuando se envía el mail de confirmación.",
+        )


### PR DESCRIPTION
The automatic delivery guide number assignment (`auto_assign_delivery_guide`) consumes a `no_gap` `ir.sequence`, whose `next_by_id()` takes a row-level lock on `ir_sequence` (`SELECT ... FOR UPDATE NOWAIT`) that is held until commit.

Assigning the number **before** `super()._action_done()` meant the lock was taken at the start of the validation and held during the whole validation work (valuation entries, backorders, confirmation emails, ...). Under concurrent or massive picking validations the other transactions exhaust the 5 concurrency retries of `odoo.service.model.retrying` and fail with `psycopg2.errors.LockNotAvailable: could not obtain lock on row in relation \"ir_sequence\"`, and each retry re-runs the whole request, making batch validations extremely slow.

**Fix:** assign the number in the `_send_confirmation_email` hook — the last step of stock's `_action_done`, right before the confirmation email goes out — so the report attached to the email still embeds the delivery guide number (the reason the early assignment existed) while the lock window shrinks to the tail of the transaction for every company, with or without confirmation email. A post-super catch-all in `_action_done` covers any flow that skips that hook.

**Tests:** `TestAutoAssignDeliveryGuide` asserts the picking is already `done` when the number is assigned, and that the number is already set at the moment the confirmation email is sent. Full module suite green locally (16 tests, 0 failures).

Also removed the do_not_assign_numbers context escape hatch (it carried a TODO asking exactly this: check whether anyone still uses it and drop it).

Why it existed: it comes from the 18.0 stock_voucher implementation, where the delivery guide used pre-printed books and several modules had competing numbering policies, using this context to suppress each other's assignment:

consumer: [stock_voucher/models/stock_picking.py#L134](https://github.com/ingadhoc/stock/blob/9aea90f8e8/stock_voucher/models/stock_picking.py#L134)
[stock_voucher_ux/models/stock_picking.py#L86-L87](https://github.com/ingadhoc/stock/blob/9aea90f8e8/stock_voucher_ux/models/stock_picking.py#L86-L87) — suppressed the base module's assignment on validation to apply its own policy (pre-printed books numbered at print time with real page count, self-printed ones only with auto_print_delivery_slip)
[stock_batch_picking_ux/models/stock_batch_picking.py#L179](https://github.com/ingadhoc/stock/blob/9aea90f8e8/stock_batch_picking_ux/models/stock_batch_picking.py#L179) — batch validation numbered the pickings itself and passed the context so downstream modules would not number them again
Why it is no longer needed in 19.0: the delivery guide is native (l10n_ar_stock), one number per picking, no books or page counts; there is a single idempotent assignment point (this module), and l10n_ar_stock_picking_batch only displays the numbers, it does not assign them. No caller sets the context anywhere: checked all local OBA/OCA repos, a GitHub code search across the ingadhoc and plugberry orgs, upgrade-line scripts and server actions/automations.

Internal ref: https://www.adhoc.inc/odoo/helpdesk.ticket/125173