### PR TITLE
[FIX] l10n_ar_stock_ux, l10n_ar_stock_picking_batch: clear CAI data when the delivery guide number is cleared

### DIFF
--- a/l10n_ar_stock_picking_batch/models/stock_picking_batch.py
+++ b/l10n_ar_stock_picking_batch/models/stock_picking_batch.py
@@ -86,11 +86,13 @@ class StockPickingBatch(models.Model):
 
     def _get_name_delivery_report(self, report_xml_id):
         """Analogous to StockPicking._get_name_delivery_report in l10n_ar_stock_ux.
-        Returns the Argentine batch report when the company is AR and a delivery
-        guide number has been assigned; otherwise falls back to the generic report.
+        Returns the Argentine batch report for any AR company batch, with or without a
+        delivery guide number: printing one by one already uses the Argentine format for
+        both cases, and printing the same transfers as a batch has to match. Without a
+        number the template degrades on its own (letter X, no CAI, no AFIP barcode).
         """
         self.ensure_one()
-        if self.company_id.country_id.code == "AR" and self.l10n_ar_delivery_guide_number:
+        if self.company_id.country_id.code == "AR":
             return "l10n_ar_stock_picking_batch.report_batch_delivery_document"
         return report_xml_id
 

--- a/l10n_ar_stock_picking_batch/tests/test_report_batch_delivery.py
+++ b/l10n_ar_stock_picking_batch/tests/test_report_batch_delivery.py
@@ -66,6 +66,22 @@ class TestL10nArBatchDeliveryReport(TransactionCase):
         self.assertFalse(self.batch.l10n_ar_cai_data)
         self._assert_no_cai_block()
 
+    def test_uses_ar_report_without_delivery_guide_number(self):
+        """El lote sin numerar también usa el comprobante argentino: las mismas
+        transferencias impresas de a una ya salen así, el lote tiene que coincidir."""
+        self.assertFalse(self.batch.l10n_ar_delivery_guide_number)
+        self.assertEqual(
+            self.batch._get_name_delivery_report("stock_batch_picking_ux.report_batch_delivery_document"),
+            "l10n_ar_stock_picking_batch.report_batch_delivery_document",
+        )
+
+    def test_renders_as_plain_voucher_without_delivery_guide_number(self):
+        """Sin número el comprobante argentino degrada solo: letra X y sin CAI."""
+        html = self._render()
+        self.assertIn(b"Comprobante de Entrega", html)
+        self.assertIn(self.batch.name.encode(), html)
+        self._assert_no_cai_block()
+
     def test_renders_with_cai_data_without_authorization_code(self):
         """Remito preimpreso adentro del lote: el dict no trae el código de CAI."""
         self.picking.write(

--- a/l10n_ar_stock_ux/models/stock_picking.py
+++ b/l10n_ar_stock_ux/models/stock_picking.py
@@ -64,6 +64,26 @@ class StockPicking(models.Model):
                 l10n_ar_delivery_guide_numbers.append(self.env.ref("l10n_ar.dc_r_r")._format_document_number(doc))
             self.l10n_ar_delivery_guide_number = ",".join(l10n_ar_delivery_guide_numbers)
 
+    def write(self, vals):
+        """Al limpiar el número de remito descartamos también la foto del CAI.
+
+        ``l10n_ar_cai_data`` congela los datos fiscales del momento en que se numeró, y de
+        ahí salen la letra, el tipo de documento y el CAI del comprobante. Si queda con los
+        datos del remito anterior, el comprobante se sigue imprimiendo como aquel remito
+        aunque ya no tenga número. Odoo no contempla el caso porque deja el campo readonly:
+        acá lo hacemos editable, así que también nos toca dejar el registro consistente.
+
+        Si el write trae `l10n_ar_cai_data` explícito respetamos ese valor: el que escribe
+        los dos campos juntos ya decidió con qué datos quiere quedarse.
+        """
+        if (
+            "l10n_ar_delivery_guide_number" in vals
+            and not vals["l10n_ar_delivery_guide_number"]
+            and "l10n_ar_cai_data" not in vals
+        ):
+            vals = dict(vals, l10n_ar_cai_data=False)
+        return super().write(vals)
+
     def _get_name_delivery_report(self, report_xml_id):
         """Method similar to the '_get_name_invoice_report' of l10n_latam_invoice_document
         Basically it allows different localizations to define it's own report

--- a/l10n_ar_stock_ux/tests/test_report_delivery.py
+++ b/l10n_ar_stock_ux/tests/test_report_delivery.py
@@ -85,8 +85,8 @@ class TestL10nArStockUxDeliveryReport(TransactionCase):
         )
         self._assert_no_cai_block()
 
-    def test_renders_with_full_cai_data(self):
-        """Remito autoimpreso: el CAI y su vencimiento salen impresos."""
+    def _number_picking(self):
+        """Deja el picking numerado como un remito autoimpreso ya emitido."""
         self.picking.write(
             {
                 "l10n_ar_delivery_guide_number": "00099-00000001",
@@ -99,5 +99,35 @@ class TestL10nArStockUxDeliveryReport(TransactionCase):
                 },
             }
         )
+
+    def test_clearing_guide_number_clears_cai_data(self):
+        """Limpiar el número descarta la foto del CAI y todo lo que se computa de ella."""
+        self._number_picking()
+        self.picking.l10n_ar_delivery_guide_number = False
+        self.assertFalse(self.picking.l10n_ar_cai_data)
+        self.assertFalse(self.picking.document_type_id)
+        self.assertFalse(self.picking.l10n_ar_cai_expiration_date)
+
+    def test_clearing_guide_number_respects_explicit_cai_data(self):
+        """Si el write trae los dos campos, gana lo que pidió quien escribe."""
+        self._number_picking()
+        cai_data = {"document_type_id": self.document_type.id}
+        self.picking.write({"l10n_ar_delivery_guide_number": False, "l10n_ar_cai_data": cai_data})
+        self.assertEqual(self.picking.l10n_ar_cai_data, cai_data)
+
+    def test_renders_as_plain_voucher_after_clearing_guide_number(self):
+        """El caso del ticket: limpiado el remito, el comprobante deja de imprimirse como
+        aquel remito (letra, tipo de documento y CAI) y vuelve al comprobante de entrega."""
+        self._number_picking()
+        self.picking.l10n_ar_delivery_guide_number = False
+        html = self._render()
+        self.assertNotIn(b"12345678901234", html)
+        self.assertNotIn(b"00099-00000001", html)
+        self.assertIn(b"Comprobante de Entrega", html)
+        self._assert_no_cai_block()
+
+    def test_renders_with_full_cai_data(self):
+        """Remito autoimpreso: el CAI y su vencimiento salen impresos."""
+        self._number_picking()
         html = self._render()
         self.assertIn(b"12345678901234", html)


### PR DESCRIPTION

l10n_ar_cai_data freezes the fiscal data of the moment the picking was numbered, and the voucher takes its letter, document type and CAI from it. Clearing the delivery guide number left that snapshot untouched, so the voucher kept printing as the previous remito. Odoo does not hit the case because it keeps the field readonly; we make it editable, so we also have to keep the record consistent. Discard the snapshot on write.

Also extend #317 to batches: stock.picking.batch still selected the Argentine report only when a guide number had been assigned, so a batch of AR transfers without one printed Odoo's generic report while those same transfers printed one by one already used the Argentine format (task 71442). Without a number the batch template degrades on its own: letter X, no CAI, no AFIP barcode.