### PR TITLE
[FIX] l10n_ar_sale: keep origin invoice reference on credit notes from SO

### DIFF
--- a/l10n_ar_sale/models/__init__.py
+++ b/l10n_ar_sale/models/__init__.py
@@ -2,5 +2,6 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from . import account_move
 from . import sale_order
 from . import sale_order_line

--- a/l10n_ar_sale/models/account_move.py
+++ b/l10n_ar_sale/models/account_move.py
@@ -1,0 +1,32 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _set_reversed_entry(self, credit_note):
+        """Cuando una NC se genera desde la orden de venta, el core solo la vincula con su
+        factura de origen si _refunds_origin_required(), que en AR es False. Sin ese vinculo
+        el comprobante sale sin ninguna referencia a la factura que le dio origen, asi que
+        al menos la dejamos en el campo Referencia."""
+        res = super()._set_reversed_entry(credit_note)
+        if (
+            len(credit_note) == 1
+            and credit_note.move_type == "out_refund"
+            and credit_note.country_code == "AR"
+            and not credit_note.ref
+            and not credit_note.reversed_entry_id
+        ):
+            # a diferencia del core, alcanza con que compartan alguna linea de la orden:
+            # asi tambien cubrimos el caso de una orden facturada en varias facturas
+            origin_invoices = self.filtered(
+                lambda inv: inv.move_type == "out_invoice"
+                and credit_note.invoice_line_ids.sale_line_ids & inv.invoice_line_ids.sale_line_ids
+            )
+            if origin_invoices:
+                credit_note.ref = ", ".join(sorted(origin_invoices.mapped("name")))
+        return res


### PR DESCRIPTION
When a sale order generates a credit note (because the amount left to invoice turned negative), `account.move._set_reversed_entry` does find the origin invoice, but it only writes `reversed_entry_id` when `_refunds_origin_required()` returns True — which is not the case for the Argentinian localization. The credit note is then left with no reference at all to the invoice it came from: the printed document only shows the sale order name as origin and the reference field is empty.

This sets the origin invoice name on `ref` when it is still empty, so the reference makes it to the printed document.

Notes:

- `reversed_entry_id` is left to the core gate on purpose. Setting it would also make the credit note reconcile automatically against its invoice on posting, which is a different (and much bigger) change.
- Unlike the core, the match only requires sharing some sale order line, so an order invoiced in several invoices lists all of them instead of falling back to nothing.
- An existing reference (the customer reference, for instance) is never overwritten.