### PR TITLE
[FIX] l10n_ar_sale: use tax_ids in _create_delivery_line

### DIFF
--- a/l10n_ar_sale/models/sale_order.py
+++ b/l10n_ar_sale/models/sale_order.py
@@ -162,7 +162,7 @@ class SaleOrder(models.Model):
             date = fields.Date.to_date(fields.Datetime.context_timestamp(self, self.date_order))
             new_taxes = self.fiscal_position_id._l10n_ar_add_taxes(self.partner_id, self.company_id, date, "perception")
             if new_taxes:
-                line.tax_id = line.tax_id | new_taxes
+                line.tax_ids = line.tax_ids | new_taxes
         return line
 
     def copy(self, default=None):


### PR DESCRIPTION
## Problem

Adding a delivery line to a sale order raises, when the order's fiscal position resolves a **non-zero AR perception** (e.g. a Responsable Inscripto customer shipping to a province with an IIBB perception):

```
File ".../l10n_ar_sale/models/sale_order.py", line 165, in _create_delivery_line
    line.tax_id = line.tax_id | new_taxes
AttributeError: 'sale.order.line' object has no attribute 'tax_id'
```

`sale.order.line` has no `tax_id` field in Odoo 19 — the taxes field is `tax_ids` (Many2many), which is what the rest of this same file already uses (`_l10n_ar_recompute_fiscal_position_taxes`). This is a stray reference introduced together with `_create_delivery_line`.

## Trigger

`_create_delivery_line` only reaches that line when a delivery line is created **and** `_l10n_ar_add_taxes` returns a non-zero perception:
- Consumidor Final: no perceptions → not reached.
- 0% perception (demo defaults): skipped by the `amount == 0` guard → not reached.
- Responsable Inscripto with a real (non-zero) perception + shipping: reached → crash.

Reproducible in the standard website checkout (`website_sale.shop_checkout` -> `_set_delivery_method`) and in the backend ("Add shipping").

## Fix

Use `tax_ids` instead of the non-existent `tax_id`:

```python
line.tax_ids = line.tax_ids | new_taxes
```

## Test plan

- RI customer subject to a non-zero perception (e.g. IIBB Buenos Aires 3%), shipping address in that province, a published product and carrier.
- eCommerce: add product -> checkout -> select delivery method -> the shipping line is created with the perception, no error.
- Backend: sale order for that customer -> add shipping -> ok.