### PR TITLE
[FIX] l10n_ar_sale: skip draft invoices in credit note reference

### DIFF
--- a/l10n_ar_sale/models/account_move.py
+++ b/l10n_ar_sale/models/account_move.py
@@ -22,9 +22,12 @@ class AccountMove(models.Model):
             and not credit_note.reversed_entry_id
         ):
             # a diferencia del core, alcanza con que compartan alguna linea de la orden:
-            # asi tambien cubrimos el caso de una orden facturada en varias facturas
+            # asi tambien cubrimos el caso de una orden facturada en varias facturas.
+            # pedimos ademas que la factura tenga numero: las que siguen en borrador tienen
+            # name False y no sirven como referencia (ademas de romper el join de abajo)
             origin_invoices = self.filtered(
                 lambda inv: inv.move_type == "out_invoice"
+                and inv.name
                 and credit_note.invoice_line_ids.sale_line_ids & inv.invoice_line_ids.sale_line_ids
             )
             if origin_invoices:

--- a/l10n_ar_sale/tests/__init__.py
+++ b/l10n_ar_sale/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_credit_note_reference

--- a/l10n_ar_sale/tests/test_credit_note_reference.py
+++ b/l10n_ar_sale/tests/test_credit_note_reference.py
@@ -1,0 +1,85 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.fields import Command
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCreditNoteReference(TestArCommon):
+    """La NC que nace de una orden de venta lleva en Referencia sus facturas de origen.
+
+    Los comprobantes se crean directamente y se le pasan a _set_reversed_entry como hace el
+    core (con todas las facturas de la orden), en lugar de facturar la orden: así el test no
+    depende de la política de facturación ni del tipo de pedido que tenga configurada la base.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.journal = cls._create_journal("preprinted")
+        cls.partner = cls.res_partner_adhoc
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": cls.product_iva_21.id,
+                            "product_uom_qty": 2.0,
+                            "price_unit": 100.0,
+                        }
+                    )
+                ],
+            }
+        )
+        cls.origin_invoice = cls._invoice_from_order(post=True)
+        assert cls.origin_invoice.name, "La factura de origen debería quedar numerada al validarse"
+
+    @classmethod
+    def _invoice_from_order(cls, move_type="out_invoice", post=False):
+        """Comprobante de la orden: lo que lo liga a ella es la línea de venta, como en el flujo real."""
+        invoice = cls._create_invoice(
+            move_type=move_type,
+            partner_id=cls.partner,
+            journal_id=cls.journal,
+            ref=False,
+            invoice_line_ids=[cls._prepare_invoice_line(product_id=cls.product_iva_21, price_unit=100.0)],
+        )
+        invoice.invoice_line_ids.sale_line_ids = [Command.set(cls.order.order_line.ids)]
+        if post:
+            invoice.action_post()
+        return invoice
+
+    def test_reference_takes_origin_invoice(self):
+        """Caso feliz: la NC referencia la factura de la que salió."""
+        credit_note = self._invoice_from_order(move_type="out_refund")
+
+        self.order.invoice_ids._set_reversed_entry(credit_note)
+
+        self.assertEqual(credit_note.ref, self.origin_invoice.name)
+
+    def test_reference_ignores_draft_invoices(self):
+        """Ticket 126371: con una factura en borrador en la orden, la NC no debe romper."""
+        draft_invoice = self._invoice_from_order()
+        self.assertFalse(draft_invoice.name, "Una factura en borrador no tiene número asignado")
+        credit_note = self._invoice_from_order(move_type="out_refund")
+
+        self.order.invoice_ids._set_reversed_entry(credit_note)
+
+        self.assertEqual(
+            credit_note.ref,
+            self.origin_invoice.name,
+            "Solo las facturas numeradas sirven como referencia",
+        )
+
+    def test_reference_empty_without_numbered_invoices(self):
+        """Si ninguna factura de origen tiene número, la NC queda sin referencia en vez de fallar."""
+        draft_invoice = self._invoice_from_order()
+        credit_note = self._invoice_from_order(move_type="out_refund")
+
+        draft_invoice._set_reversed_entry(credit_note)
+
+        self.assertFalse(credit_note.ref)


### PR DESCRIPTION
## Problema

Al validar una entrega que dispara la facturación automática de la orden, el flujo revienta con:

```
File ".../l10n_ar_sale/models/account_move.py", line 31, in _set_reversed_entry
    credit_note.ref = ", ".join(sorted(origin_invoices.mapped("name")))
TypeError: sequence item 0: expected str instance, bool found
```

`_set_reversed_entry` lo llama el core con `sale_order.invoice_ids`, o sea **todas** las facturas de la orden, borradores incluidos. Una factura en borrador todavía no tiene número: `name` es `False`, y el `join` sobre los nombres rompe.

Alcanza con que la orden tenga una factura en borrador que comparta línea con la nota de crédito. Regresión de 573f6a0 (#327).

## Solución

Pedir que la factura de origen tenga número. Si ninguna lo tiene, la NC queda sin referencia, que es el comportamiento previo a esa función.

```python
origin_invoices = self.filtered(
    lambda inv: inv.move_type == "out_invoice"
    and inv.name
    and credit_note.invoice_line_ids.sale_line_ids & inv.invoice_line_ids.sale_line_ids
)
```

## Test plan

Primeros tests del módulo, en `l10n_ar_sale/tests/test_credit_note_reference.py`:

- `test_reference_takes_origin_invoice` — la NC referencia la factura de la que salió
- `test_reference_ignores_draft_invoices` — con una factura en borrador en la orden, no rompe y referencia solo la numerada
- `test_reference_empty_without_numbered_invoices` — sin ninguna factura numerada, la NC queda sin referencia en vez de fallar

Los comprobantes se crean directamente y se le pasan a `_set_reversed_entry` igual que hace el core (con todas las facturas de la orden), en lugar de facturar la orden: facturar hace depender el test de la política de facturación y del tipo de pedido configurados en la base, que varían entre una instalación mínima y una con todo instalado.

Verificado en los dos sentidos sobre 18.0: con el fix pasan los 3; quitando solo el `and inv.name`, fallan 2 de 3 — uno con el `TypeError` de arriba y el otro con `'<' not supported between instances of 'str' and 'bool'` al ordenar los nombres.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/126371