### PR TITLE
[ADD] l10n_ar_stock_preprinted_aeroo: print the pre-printed remito from an .odt

### DIFF
--- a/l10n_ar_stock_preprinted_aeroo/README.rst
+++ b/l10n_ar_stock_preprinted_aeroo/README.rst
@@ -1,0 +1,102 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=========================================
+Remito Preimpreso con plantilla Aeroo
+=========================================
+
+Permite imprimir el **remito preimpreso** con una plantilla ``.odt`` propia en
+lugar del comprobante qweb de ``l10n_ar_stock_preprinted``.
+
+El papel de un talonario preimpreso lo arma cada imprenta, así que el layout
+cambia de cliente a cliente: dónde caen los campos, cuántos renglones entran,
+qué espacio queda libre. Un comprobante qweb no se puede acomodar a cada papel
+sin tocar el template. Con este módulo el layout es un dato de configuración:
+se sube el ``.odt`` en el tipo de operación y listo.
+
+Se instala solo (``auto_install``) cuando la base ya tiene
+``l10n_ar_stock_preprinted`` y ``report_aeroo``.
+
+Qué agrega
+==========
+
+En el tipo de operación, junto al *Modo de Impresión del Remito* y solo cuando
+está en preimpreso:
+
+* **Plantilla del Remito Preimpreso** — el ``.odt`` del talonario.
+* **Renglones por Hoja** — cuántos renglones de producto entran en una hoja.
+
+Cómo reemplaza al comprobante
+=============================
+
+No agrega una entrada nueva al menú *Imprimir*: el reporte aeroo **reemplaza**
+al comprobante de entrega cuando corresponde, así que se sigue imprimiendo desde
+donde siempre (el botón de imprimir y el de numerar-e-imprimir).
+
+El reemplazo aplica cuando todos los remitos que se están imprimiendo son de un
+mismo tipo de operación preimpreso con plantilla cargada. Un lote mixto —- dos
+talonarios distintos, o uno con plantilla y otro sin —- sale por el comprobante
+qweb de siempre: no hay un reporte que sirva para los dos.
+
+Es un solo reporte para todos los talonarios: la plantilla no está fija en el
+reporte (``tml_source = 'parser'``), se lee del tipo de operación del remito que
+se está imprimiendo.
+
+Cómo se cuentan las hojas
+=========================
+
+En preimpreso cada hoja consumida se lleva un número de la secuencia, así que
+hay que saber cuántas hojas ocupa el remito. Con el comprobante qweb eso se
+resuelve renderizando y contando páginas. Con una plantilla ``.odt`` no se
+puede: la paginación la decide la plantilla del cliente, no Odoo.
+
+Por eso las hojas se **calculan** a partir de los renglones por hoja del
+talonario, que además es el mismo criterio con el que la imprenta armó el papel:
+
+* 25 renglones con 10 renglones por hoja → 3 hojas, 3 números.
+* Un remito sin renglones consume igual una hoja.
+
+Los renglones son los mismos que imprime el comprobante de entrega: antes de
+validar, los movimientos con cantidad pedida; después, un renglón por movimiento
+de detalle cuando se imprimen series y los renglones agregados por producto
+cuando no.
+
+Sin plantilla cargada el conteo no cambia: se siguen contando las páginas
+renderizadas del comprobante qweb.
+
+Bugs / Roadmap
+==============
+
+* Un lote con dos talonarios distintos sale por qweb en vez de partirse en un
+  PDF por talonario.
+* Los títulos de sección de paquete no cuentan como renglón: se asume que el
+  talonario los absorbe.
+
+Credits
+=======
+
+Contributors
+------------
+
+Images
+------
+
+* |company| |icon|
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://github.com/ingadhoc.

--- a/l10n_ar_stock_preprinted_aeroo/__init__.py
+++ b/l10n_ar_stock_preprinted_aeroo/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import report

--- a/l10n_ar_stock_preprinted_aeroo/__manifest__.py
+++ b/l10n_ar_stock_preprinted_aeroo/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "Remito Preimpreso con plantilla Aeroo",
+    "version": "19.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Imprime el remito preimpreso con una plantilla .odt del cliente en vez del comprobante qweb",
+    "depends": [
+        "l10n_ar_stock_preprinted",
+        "report_aeroo",
+    ],
+    "data": [
+        "report/report_delivery_preprinted.xml",
+        "views/stock_picking_type_views.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+    "application": False,
+}

--- a/l10n_ar_stock_preprinted_aeroo/models/__init__.py
+++ b/l10n_ar_stock_preprinted_aeroo/models/__init__.py
@@ -1,0 +1,3 @@
+from . import ir_actions_report
+from . import stock_picking
+from . import stock_picking_type

--- a/l10n_ar_stock_preprinted_aeroo/models/ir_actions_report.py
+++ b/l10n_ar_stock_preprinted_aeroo/models/ir_actions_report.py
@@ -1,0 +1,38 @@
+from odoo import models
+
+DELIVERY_REPORT = "stock.action_report_delivery"
+PREPRINTED_AEROO_REPORT = "l10n_ar_stock_preprinted_aeroo.report_delivery_preprinted_aeroo"
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def report_action(self, docids, data=None, config=True):
+        """El botón Imprimir del remito y el de numerar-e-imprimir apuntan siempre al comprobante
+        de entrega qweb. Cuando todos los remitos del lote tienen plantilla .odt, imprimimos el
+        reporte aeroo en su lugar: es el mismo comprobante, con el layout del talonario del
+        cliente. Reemplazamos acá y no en cada botón para tomar los dos caminos con un solo
+        override."""
+        aeroo_report = self._l10n_ar_preprinted_aeroo_report(docids)
+        if aeroo_report:
+            return aeroo_report.report_action(docids, data=data, config=config)
+        return super().report_action(docids, data=data, config=config)
+
+    def _l10n_ar_preprinted_aeroo_report(self, docids):
+        """El reporte aeroo con el que hay que reemplazar este, o False si no aplica.
+
+        Pedimos un solo tipo de operación a propósito: con un lote mixto (un remito con plantilla
+        y otro sin, o dos talonarios distintos) no hay un reporte que sirva para todos, así que se
+        imprime el comprobante qweb, que es el comportamiento de siempre. No hay recursión porque
+        el reporte que devolvemos nunca es el comprobante de entrega."""
+        delivery_report = self.env.ref(DELIVERY_REPORT, raise_if_not_found=False)
+        if len(self) != 1 or not delivery_report or self != delivery_report:
+            return False
+        pickings = docids if isinstance(docids, models.Model) else self.env["stock.picking"].browse(docids)
+        if not pickings or pickings._name != "stock.picking":
+            return False
+        if len(pickings.picking_type_id) != 1:
+            return False
+        if not all(picking._l10n_ar_preprinted_aeroo_template() for picking in pickings):
+            return False
+        return self.env.ref(PREPRINTED_AEROO_REPORT, raise_if_not_found=False)

--- a/l10n_ar_stock_preprinted_aeroo/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted_aeroo/models/stock_picking.py
@@ -1,0 +1,43 @@
+import math
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _l10n_ar_preprinted_aeroo_template(self):
+        """Plantilla .odt con la que hay que imprimir este remito, o False si no hay ninguna y el
+        comprobante sale por el camino qweb de siempre. Pedimos también el modo preimpreso: una
+        plantilla cargada en un tipo autoimpreso no aplica, porque ahí Odoo imprime el comprobante
+        completo (encabezado, número y CAI) y la plantilla del talonario no lo trae."""
+        self.ensure_one()
+        if self.l10n_ar_voucher_print_mode != "preprinted":
+            return False
+        return self.picking_type_id.l10n_ar_preprinted_template or False
+
+    def _l10n_ar_preprinted_line_count(self):
+        """Renglones de producto del comprobante. Es la misma cuenta que hace el comprobante de
+        entrega de Odoo: antes de validar, los movimientos con cantidad pedida; después, un renglón
+        por movimiento de detalle cuando se imprimen series y los renglones agregados por producto
+        cuando no. Los títulos de sección de paquete no se cuentan: son del layout, no renglones de
+        producto."""
+        self.ensure_one()
+        if self.state != "done":
+            return len(self.move_ids.filtered(lambda m: m.product_uom_qty))
+        move_lines = self.move_ids.move_line_ids
+        if move_lines.lot_id and self.env.user.has_group("stock.group_lot_on_delivery_slip"):
+            return len(move_lines)
+        return len(move_lines._get_aggregated_product_quantities())
+
+    def _l10n_ar_count_preprinted_sheets(self):
+        """Con plantilla .odt las hojas no se pueden contar renderizando: la paginación la decide
+        LibreOffice sobre la plantilla del cliente, y la marca invisible con la que el comprobante
+        qweb reconoce las hojas con productos no existe ahí. El talonario preimpreso trae una
+        cantidad fija de renglones por hoja, así que las hojas se calculan a partir de eso, que
+        además es el mismo criterio con el que la imprenta armó el papel."""
+        self.ensure_one()
+        if not self._l10n_ar_preprinted_aeroo_template():
+            return super()._l10n_ar_count_preprinted_sheets()
+        lines_per_sheet = self.picking_type_id.l10n_ar_preprinted_lines_per_sheet
+        return max(1, math.ceil(self._l10n_ar_preprinted_line_count() / lines_per_sheet))

--- a/l10n_ar_stock_preprinted_aeroo/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted_aeroo/models/stock_picking_type.py
@@ -1,0 +1,42 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    l10n_ar_preprinted_template = fields.Binary(
+        string="Plantilla del Remito Preimpreso",
+        attachment=True,
+        help="Plantilla .odt con el layout del talonario de la imprenta. Si se carga, el remito de "
+        "este tipo de operación se imprime con esta plantilla en lugar del comprobante estándar de "
+        "Odoo. La plantilla es un dato de configuración: no hace falta crear un reporte a mano.",
+    )
+    l10n_ar_preprinted_template_filename = fields.Char()
+    l10n_ar_preprinted_lines_per_sheet = fields.Integer(
+        string="Renglones por Hoja",
+        help="Cuántos renglones de producto entran en una hoja del talonario. Con plantilla .odt "
+        "las hojas no se cuentan renderizando (la paginación la decide la plantilla, no Odoo), se "
+        "calculan con este número: un remito de 25 renglones con 10 renglones por hoja consume 3 "
+        "hojas, o sea 3 números de la secuencia.",
+    )
+
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains("l10n_ar_preprinted_template", "l10n_ar_preprinted_lines_per_sheet")
+    def _constrains_l10n_ar_preprinted_lines_per_sheet(self):
+        """Sin renglones por hoja el conteo devolvería siempre una hoja y el remito consumiría un
+        solo número aunque ocupe varias, que es justo lo que el preimpreso tiene que evitar. Solo
+        se exige cuando hay plantilla cargada: sin plantilla imprime el comprobante qweb y las
+        hojas se siguen contando renderizando."""
+        for picking_type in self.filtered(lambda x: x.l10n_ar_preprinted_template):
+            if picking_type.l10n_ar_preprinted_lines_per_sheet <= 0:
+                raise ValidationError(
+                    _(
+                        "En el tipo de operación %(picking_type)s cargó una plantilla de remito"
+                        " preimpreso, así que debe indicar cuántos renglones entran en una hoja del"
+                        " talonario. Es el número con el que se calcula cuántas hojas (y cuántos"
+                        " números) consume cada remito.",
+                        picking_type=picking_type.display_name,
+                    )
+                )

--- a/l10n_ar_stock_preprinted_aeroo/report/__init__.py
+++ b/l10n_ar_stock_preprinted_aeroo/report/__init__.py
@@ -1,0 +1,1 @@
+from . import report_delivery_preprinted

--- a/l10n_ar_stock_preprinted_aeroo/report/report_delivery_preprinted.py
+++ b/l10n_ar_stock_preprinted_aeroo/report/report_delivery_preprinted.py
@@ -1,0 +1,29 @@
+from base64 import b64decode
+
+from odoo import models
+
+
+class ReportDeliveryPreprinted(models.AbstractModel):
+    _name = "report.l10n_ar_preprinted_aeroo"
+    _inherit = "report.report_aeroo.abstract"
+    _description = "Remito Preimpreso Aeroo"
+
+    def aeroo_report(self, docids, data):
+        """Aeroo resuelve la plantilla de un reporte ``tml_source = 'parser'`` con el ``active_id``
+        del contexto y, si no está, con ``data['id']`` (``report_parser.py``, ``complex_report``).
+        Imprimiendo desde un botón no viene ninguno de los dos —- ``data`` llega en ``None`` y la
+        expresión ni siquiera se puede evaluar -—, así que fijamos el registro acá, que es el único
+        punto del flujo donde tenemos los docids con seguridad.
+
+        Tomamos el primero: el reemplazo del comprobante exige un solo tipo de operación por lote,
+        así que todos los remitos del lote comparten talonario."""
+        parser = self.with_context(active_id=docids[0])
+        return super(ReportDeliveryPreprinted, parser).aeroo_report(docids, data or {})
+
+    def get_template(self, record):
+        """Hook de aeroo para ``tml_source = 'parser'``: la plantilla no es fija, sale del tipo de
+        operación del remito que se está imprimiendo. Así un solo reporte sirve para todos los
+        talonarios del cliente y la plantilla queda como dato de configuración, en vez de un
+        reporte hecho a mano por cada tipo de operación."""
+        template = record._l10n_ar_preprinted_aeroo_template()
+        return b64decode(template) if template else False

--- a/l10n_ar_stock_preprinted_aeroo/report/report_delivery_preprinted.xml
+++ b/l10n_ar_stock_preprinted_aeroo/report/report_delivery_preprinted.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- Un único reporte aeroo para todos los talonarios del cliente. La plantilla no está fija
+         acá: tml_source = 'parser' hace que aeroo se la pida al parser_model, que la lee del tipo
+         de operación del remito que se está imprimiendo (ver report_delivery_preprinted.py).
+
+         No lleva binding_model_id a propósito: no queremos una segunda entrada en el menú
+         Imprimir. Al reporte se llega reemplazando al comprobante de entrega cuando corresponde
+         (ver models/ir_actions_report.py), así el cliente sigue imprimiendo desde donde siempre.
+
+         Al venir de un módulo el reporte tiene external id propio, así que no cuenta como
+         personalización de la base, que es lo que sí pasaba cuando cada cliente se armaba su
+         propio reporte aeroo a mano. -->
+    <record id="report_delivery_preprinted_aeroo" model="ir.actions.report">
+        <field name="name">Remito Preimpreso</field>
+        <field name="model">stock.picking</field>
+        <field name="report_type">aeroo</field>
+        <field name="report_name">l10n_ar_stock_preprinted_aeroo.report_delivery_preprinted</field>
+        <field name="parser_model">report.l10n_ar_preprinted_aeroo</field>
+        <field name="tml_source">parser</field>
+        <field name="in_format">oo-odt</field>
+        <field name="out_format" ref="report_aeroo.report_mimetypes_pdf_odt"/>
+    </record>
+</odoo>

--- a/l10n_ar_stock_preprinted_aeroo/tests/__init__.py
+++ b/l10n_ar_stock_preprinted_aeroo/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_preprinted_aeroo

--- a/l10n_ar_stock_preprinted_aeroo/tests/test_preprinted_aeroo.py
+++ b/l10n_ar_stock_preprinted_aeroo/tests/test_preprinted_aeroo.py
@@ -1,0 +1,156 @@
+from base64 import b64encode
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+TEMPLATE = b64encode(b"plantilla odt de prueba")
+
+
+class TestPreprintedAeroo(TransactionCase):
+    """El reemplazo del comprobante qweb por la plantilla .odt del talonario, y el conteo de hojas
+    por renglones que va con él."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.document_type = cls.env.ref("l10n_ar.dc_r_r")
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito preimpreso aeroo test",
+                "sequence_code": "TESTAEROO",
+                "code": "outgoing",
+                "company_id": cls.env.company.id,
+                "warehouse_id": cls.env["stock.warehouse"]
+                .search([("company_id", "=", cls.env.company.id)], limit=1)
+                .id,
+                "l10n_ar_document_type_id": cls.document_type.id,
+                "l10n_ar_voucher_print_mode": "preprinted",
+            }
+        )
+        cls.picking_type.l10n_ar_delivery_sequence_prefix = "00099"
+        cls.product = cls.env["product.product"].create({"name": "Producto aeroo test", "type": "consu"})
+        cls.delivery_report = cls.env.ref("stock.action_report_delivery")
+        cls.aeroo_report = cls.env.ref("l10n_ar_stock_preprinted_aeroo.report_delivery_preprinted_aeroo")
+
+    def _picking(self, lines=1, picking_type=None):
+        return self.env["stock.picking"].create(
+            {
+                "picking_type_id": (picking_type or self.picking_type).id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+                "move_ids": [(0, 0, {"product_id": self.product.id, "product_uom_qty": 1.0}) for __ in range(lines)],
+            }
+        )
+
+    def _load_template(self, lines_per_sheet=10):
+        self.picking_type.write(
+            {
+                "l10n_ar_preprinted_template": TEMPLATE,
+                "l10n_ar_preprinted_lines_per_sheet": lines_per_sheet,
+            }
+        )
+
+    # === la plantilla solo aplica en preimpreso === #
+
+    def test_template_needs_preprinted_mode(self):
+        """Una plantilla cargada en un tipo autoimpreso no aplica: ahí Odoo imprime el comprobante
+        completo y la plantilla del talonario no trae encabezado ni CAI."""
+        self._load_template()
+        # el autoimpreso exige los datos de CAI, que en preimpreso vienen impresos en el papel
+        self.picking_type.write(
+            {
+                "l10n_ar_voucher_print_mode": "autoprinted",
+                "l10n_ar_cai_authorization_code": "12345678901234",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "00001000",
+            }
+        )
+        self.assertFalse(self._picking()._l10n_ar_preprinted_aeroo_template())
+
+    def test_no_template_keeps_qweb(self):
+        """Sin plantilla cargada no cambia nada: sigue el comprobante de entrega de siempre."""
+        picking = self._picking()
+        self.assertFalse(picking._l10n_ar_preprinted_aeroo_template())
+        self.assertFalse(self.delivery_report._l10n_ar_preprinted_aeroo_report(picking))
+
+    # === reemplazo del reporte === #
+
+    def test_template_replaces_delivery_report(self):
+        """Con plantilla cargada, imprimir el comprobante de entrega imprime el reporte aeroo."""
+        self._load_template()
+        picking = self._picking()
+        self.assertEqual(self.delivery_report._l10n_ar_preprinted_aeroo_report(picking), self.aeroo_report)
+        # config=False para no caer en el wizard de layout de la compañía, que envuelve la acción
+        action = self.delivery_report.report_action(picking, config=False)
+        self.assertEqual(action["report_name"], self.aeroo_report.report_name)
+
+    def test_other_reports_untouched(self):
+        """El reemplazo es solo del comprobante de entrega: cualquier otro reporte se imprime como
+        siempre, aunque el remito tenga plantilla."""
+        self._load_template()
+        picking = self._picking()
+        other_report = self.env.ref("stock.action_report_picking")
+        self.assertFalse(other_report._l10n_ar_preprinted_aeroo_report(picking))
+
+    def test_mixed_picking_types_keep_qweb(self):
+        """Un lote con dos talonarios distintos no tiene un reporte que sirva para los dos: se
+        imprime el comprobante qweb, que es el comportamiento de siempre."""
+        self._load_template()
+        other_type = self.picking_type.copy({"name": "Otro talonario", "sequence_code": "TESTAEROO2"})
+        pickings = self._picking() | self._picking(picking_type=other_type)
+        self.assertFalse(self.delivery_report._l10n_ar_preprinted_aeroo_report(pickings))
+
+    def test_one_picking_without_template_keeps_qweb(self):
+        """Si en el lote hay un remito sin plantilla, el lote entero sale por qweb."""
+        self._load_template()
+        picking = self._picking()
+        self.picking_type.l10n_ar_preprinted_template = False
+        self.assertFalse(self.delivery_report._l10n_ar_preprinted_aeroo_report(picking))
+
+    # === la plantilla sale del tipo de operación === #
+
+    def test_parser_reads_template_from_picking_type(self):
+        """El parser de aeroo resuelve la plantilla contra el remito que se está imprimiendo, así
+        un solo reporte sirve para todos los talonarios del cliente."""
+        self._load_template()
+        parser = self.env["report.l10n_ar_preprinted_aeroo"]
+        self.assertEqual(parser.get_template(self._picking()), b"plantilla odt de prueba")
+
+    # === conteo de hojas por renglones === #
+
+    def test_sheets_by_lines_per_sheet(self):
+        """Las hojas salen de los renglones, no de renderizar: 25 renglones a 10 por hoja son 3."""
+        self._load_template(lines_per_sheet=10)
+        self.assertEqual(self._picking(lines=25)._l10n_ar_count_preprinted_sheets(), 3)
+
+    def test_sheets_exact_multiple(self):
+        """Un remito que llena las hojas justas no arrastra una hoja de más."""
+        self._load_template(lines_per_sheet=10)
+        self.assertEqual(self._picking(lines=20)._l10n_ar_count_preprinted_sheets(), 2)
+
+    def test_sheets_minimum_one(self):
+        """Un remito sin renglones consume igual una hoja: la del papel que se imprimió."""
+        self._load_template(lines_per_sheet=10)
+        self.assertEqual(self._picking(lines=0)._l10n_ar_count_preprinted_sheets(), 1)
+
+    def test_numbering_uses_one_number_per_sheet(self):
+        """El remito toma un número por hoja consumida, como el flujo preimpreso de siempre, pero
+        con las hojas calculadas."""
+        self._load_template(lines_per_sheet=10)
+        picking = self._picking(lines=25)
+        picking.l10n_ar_action_create_delivery_guide()
+        self.assertEqual(len(picking.l10n_ar_delivery_guide_number.split(",")), 3)
+
+    # === la validación de renglones por hoja === #
+
+    def test_template_requires_lines_per_sheet(self):
+        """Sin renglones por hoja el conteo daría siempre una hoja y el remito consumiría un solo
+        número aunque ocupe varias."""
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_preprinted_template = TEMPLATE
+
+    def test_lines_per_sheet_not_required_without_template(self):
+        """Sin plantilla el campo no se pide: las hojas se cuentan renderizando el qweb."""
+        self.picking_type.l10n_ar_preprinted_lines_per_sheet = 0
+        self.assertFalse(self.picking_type.l10n_ar_preprinted_template)

--- a/l10n_ar_stock_preprinted_aeroo/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted_aeroo/views/stock_picking_type_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- La plantilla del talonario y sus renglones por hoja son configuración del tipo de
+         operación, al lado del Modo de Impresión del Remito que las gobierna: solo tienen sentido
+         en preimpreso, porque en autoimpreso Odoo imprime el comprobante completo. -->
+    <record id="view_picking_type_form_preprinted_aeroo" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.preprinted.aeroo</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="l10n_ar_stock_preprinted.view_picking_type_form_preprinted"/>
+        <field name="arch" type="xml">
+            <field name="l10n_ar_voucher_print_mode" position="after">
+                <field name="l10n_ar_preprinted_template_filename" invisible="1"/>
+                <field name="l10n_ar_preprinted_template"
+                       filename="l10n_ar_preprinted_template_filename"
+                       invisible="not l10n_ar_document_type_id or l10n_ar_voucher_print_mode != 'preprinted'"/>
+                <field name="l10n_ar_preprinted_lines_per_sheet"
+                       required="l10n_ar_preprinted_template"
+                       invisible="not l10n_ar_document_type_id or l10n_ar_voucher_print_mode != 'preprinted' or not l10n_ar_preprinted_template"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Task #73120.

## Por qué

El papel de un talonario de remitos preimpresos lo arma cada imprenta, así que el
layout cambia de cliente a cliente: dónde caen los campos, cuántos renglones entran,
qué espacio queda libre. El comprobante qweb de `l10n_ar_stock_preprinted` no se
puede acomodar a cada papel sin tocar el template.

Hoy eso se resuelve creando a mano un reporte Aeroo sobre `stock.picking` en cada
base. Funciona, pero queda como un registro suelto sin external id: no se versiona,
no se soporta, y la base lo cuenta como personalización.

## Qué agrega

Módulo puente `l10n_ar_stock_preprinted_aeroo`, `auto_install` sobre
`l10n_ar_stock_preprinted` + `report_aeroo`. Sube el `.odt` como configuración del
tipo de operación y listo.

En el tipo de operación, junto al *Modo de Impresión del Remito* y solo en preimpreso:

- **Plantilla del Remito Preimpreso** — el `.odt` del talonario.
- **Renglones por Hoja** — cuántos renglones de producto entran en una hoja.

## Cómo reemplaza al comprobante

No agrega una entrada nueva al menú Imprimir: el reporte Aeroo **reemplaza** al
comprobante de entrega, así que se sigue imprimiendo desde donde siempre (el botón
de imprimir y el de numerar-e-imprimir, con un solo override en `report_action`).

El reemplazo aplica cuando todos los remitos del lote son de un mismo tipo de
operación preimpreso con plantilla cargada. Un lote mixto (dos talonarios distintos,
o uno con plantilla y otro sin) sale por qweb: no hay un reporte que sirva para los
dos.

Es **un solo reporte** para todos los talonarios. La plantilla no está fija en el
reporte: `tml_source = 'parser'` hace que Aeroo se la pida al `parser_model`, que la
lee del tipo de operación del remito que se está imprimiendo.

## El conteo de hojas

En preimpreso cada hoja consumida se lleva un número de la secuencia. Con el
comprobante qweb eso se resuelve renderizando y contando las páginas que traen la
marca invisible de línea de producto. Con un `.odt` no se puede: la paginación la
decide la plantilla del cliente, no Odoo, y la marca no existe ahí.

Por eso con plantilla las hojas se **calculan** desde los renglones por hoja del
talonario, que es el mismo criterio con el que la imprenta armó el papel: 25
renglones a 10 por hoja son 3 hojas, o sea 3 números. Sin plantilla el conteo no
cambia: se sigue renderizando el qweb.

Los renglones son los mismos que imprime el comprobante de entrega: antes de validar,
los movimientos con cantidad pedida; después, un renglón por movimiento de detalle
cuando se imprimen series y los renglones agregados por producto cuando no.

## Detalle de implementación

`aeroo_report` se override en el parser porque Aeroo resuelve la plantilla de un
`tml_source = 'parser'` con `ctx['active_id']` y, si no está, con `data['id']`
(`report_parser.py`, `complex_report`). Imprimiendo desde un botón no viene ninguno
de los dos — `data` llega en `None` y la expresión ni siquiera se puede evaluar — así
que el registro se fija en el único punto del flujo donde los docids están
garantizados. El arreglo de fondo va en `report_aeroo`; acá queda acotado al reporte
de este módulo.

## Test plan

`--test-tags /l10n_ar_stock_preprinted_aeroo` — 12 casos: que la plantilla solo
aplique en preimpreso, el reemplazo del comprobante y los casos en que NO reemplaza
(otro reporte, lote mixto, un remito sin plantilla), que el parser lea la plantilla
del tipo de operación, el conteo de hojas (múltiplo exacto, con resto, sin renglones),
que la numeración tome un número por hoja calculada, y la validación de renglones por
hoja.

## Depende de

- ingadhoc/aeroo_reports#100 — sin ese fix, la constraint `_check_parser_model` rechaza
  el `parser_model` de este módulo y el data file aborta la instalación. Mismo nombre de
  rama, así que van juntos en el build.
