### PR TITLE
[ADD] l10n_ar_stock_preprinted: plantilla QWeb propia por tipo de operación

### DIFF
--- a/l10n_ar_stock_preprinted/README.rst
+++ b/l10n_ar_stock_preprinted/README.rst
@@ -50,6 +50,35 @@ Qué agrega
   copias consume un solo número por hoja.
 * Reporte: en preimpreso el remito se imprime sin encabezado, sin número y sin
   CAI (ya vienen en el papel).
+* ``stock.picking.type.l10n_ar_preprinted_report_view_id`` (opcional): plantilla
+  QWeb propia con la que se imprime el remito de ese tipo de operación, en lugar
+  del comprobante estándar. Ver *Plantilla propia* más abajo.
+
+Plantilla propia
+================
+
+Cada imprenta entrega el talonario con su propia grilla, y el comprobante
+estándar no siempre cae donde el papel lo espera. Para eso el tipo de operación
+acepta una **plantilla QWeb propia**, que la hace un consultor funcional desde la
+interfaz —sin módulo, sin deploy— en *Ajustes > Técnico > Vistas*:
+
+#. Crear una vista de tipo *QWeb* con un ``<t t-name="...">`` propio. No es una
+   herencia del comprobante estándar: es una plantilla desde cero, dibujada para
+   la grilla del papel.
+#. La plantilla recibe el picking en la variable ``o`` y el tipo de copia en
+   ``copy_type``, y tiene que abrir con ``<t t-call="web.html_container">`` igual
+   que el comprobante estándar.
+#. Seleccionarla en *Plantilla del Remito Preimpreso*, en el tipo de operación.
+
+Vacío el campo, se usa el comprobante estándar y no cambia nada.
+
+**Numeración con plantilla propia.** El comprobante estándar descuenta del conteo
+las hojas que solo traen firma, totales o datos del transportista, apoyándose en
+una marca invisible que imprime por cada línea de producto. Una plantilla propia
+no emite esa marca, así que el criterio cambia: se cuentan **todas las páginas**
+que se imprimen, porque una plantilla dibujada para el papel de la imprenta no
+emite hojas que no sean del talonario. El juego de copias
+(duplicado / triplicado) sigue consumiendo un solo número por hoja.
 
 Configuración
 =============

--- a/l10n_ar_stock_preprinted/__manifest__.py
+++ b/l10n_ar_stock_preprinted/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Remito Preimpreso para Argentina",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_stock_preprinted/models/stock_picking.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking.py
@@ -29,6 +29,14 @@ class StockPicking(models.Model):
         layout preimpreso — los dos casos requieren el template argentino."""
         self.ensure_one()
         if self.company_id.country_id.code == "AR" and self.l10n_ar_voucher_print_mode == "preprinted":
+            # Si el tipo de operación tiene plantilla propia, el comprobante se imprime con esa.
+            # Devolvemos el key y no el external id porque el t-call resuelve los templates por
+            # ir.ui.view.key (_get_template_domain), y una vista hecha desde la interfaz no tiene
+            # external id; key en cambio siempre tiene (lo exige el constraint de base, y Odoo lo
+            # autogenera cuando no se lo dan).
+            custom_view = self.picking_type_id.l10n_ar_preprinted_report_view_id
+            if custom_view:
+                return custom_view.key
             return "l10n_ar_stock_ux.report_delivery_document"
         return super()._get_name_delivery_report(report_xml_id)
 
@@ -77,6 +85,14 @@ class StockPicking(models.Model):
         pdf_reader = PdfReader(BytesIO(pdf_content))
         copies = COPIES_BY_L10N_AR_COPIES.get(report.l10n_ar_copies, 1)
         pages_per_copy = len(pdf_reader.pages) // copies
+        if self.picking_type_id.l10n_ar_preprinted_report_view_id:
+            # Con plantilla propia contamos TODAS las páginas de una copia. La marca de línea
+            # la inyectan herencias sobre los leaf-templates del comprobante estándar, y una
+            # plantilla hecha desde cero no los llama: contar por marca daría cero marcas — una
+            # sola hoja, sin aviso, para un remito de varias. Y además no hace falta discriminar:
+            # una plantilla dibujada para el papel de la imprenta no emite hojas que no sean del
+            # talonario, así que cada página que sale consume un número.
+            return max(1, pages_per_copy)
         sheets = self._l10n_ar_count_pages_with_products(pdf_reader)
         return max(1, min(sheets, pages_per_copy))
 

--- a/l10n_ar_stock_preprinted/models/stock_picking_type.py
+++ b/l10n_ar_stock_preprinted/models/stock_picking_type.py
@@ -21,6 +21,21 @@ class StockPickingType(models.Model):
         "acá porque viene impreso en el papel.",
     )
 
+    l10n_ar_preprinted_report_view_id = fields.Many2one(
+        "ir.ui.view",
+        string="Plantilla del Remito Preimpreso",
+        domain=[("type", "=", "qweb"), ("mode", "=", "primary")],
+        ondelete="restrict",
+        help="Vista QWeb propia con la que se imprime el remito de este tipo de operación, en lugar "
+        "del comprobante estándar. Sirve para adaptar el contenido variable a la grilla del papel "
+        "de la imprenta, que cada talonario trae distinta.\n"
+        "La plantilla se crea desde Ajustes > Técnico > Vistas y recibe el picking en la variable "
+        "'o' (y el tipo de copia en 'copy_type'); tiene que abrir con "
+        '<t t-call="web.html_container"> igual que el comprobante estándar.\n'
+        "Con una plantilla propia la numeración cuenta TODAS las páginas que se imprimen: cada "
+        "página es una hoja del talonario. Vacío, se usa el comprobante estándar.",
+    )
+
     # === CONSTRAINT METHODS === #
 
     @api.constrains(
@@ -57,5 +72,29 @@ class StockPickingType(models.Model):
                         " como Preimpreso.",
                         picking_type=picking_type.display_name,
                         fields=", ".join(missing),
+                    )
+                )
+
+    @api.constrains("l10n_ar_preprinted_report_view_id")
+    def _constrains_l10n_ar_preprinted_report_view(self):
+        """La plantilla tiene que ser una vista QWeb autónoma. El domain del campo ya lo pide,
+        pero el modo también puede setearse por import / data / ORM, donde el domain no aplica.
+
+        El chequeo de 'primary' no es cosmético: una vista de herencia (mode = 'extension') no
+        tiene arch renderizable propio — es un diff de xpaths — así que el t-call del comprobante
+        imprimiría los nodos del diff sueltos en vez del remito."""
+        for picking_type in self.filtered("l10n_ar_preprinted_report_view_id"):
+            view = picking_type.l10n_ar_preprinted_report_view_id
+            if view.type != "qweb" or view.mode != "primary":
+                raise ValidationError(
+                    _(
+                        "La plantilla del remito preimpreso de %(picking_type)s tiene que ser una"
+                        " vista QWeb autónoma, y %(view)s es de tipo %(type)s y modo"
+                        " %(mode)s.\nCree la plantilla desde Ajustes > Técnico > Vistas con un"
+                        " <t t-name> propio, sin vista heredada.",
+                        picking_type=picking_type.display_name,
+                        view=view.display_name,
+                        type=view.type,
+                        mode=view.mode,
                     )
                 )

--- a/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
+++ b/l10n_ar_stock_preprinted/tests/test_voucher_print_mode.py
@@ -18,8 +18,8 @@ def _pdf_with_pages(pages):
     return stream.getvalue()
 
 
-class TestVoucherPrintMode(TransactionCase):
-    """El modo de impresión del remito y la numeración que se deriva de él."""
+class PreprintedCommon(TransactionCase):
+    """Tipo de operación preimpreso con un remito de una línea, base de los dos casos."""
 
     @classmethod
     def setUpClass(cls):
@@ -57,6 +57,10 @@ class TestVoucherPrintMode(TransactionCase):
                 ],
             }
         )
+
+
+class TestVoucherPrintMode(PreprintedCommon):
+    """El modo de impresión del remito y la numeración que se deriva de él."""
 
     def test_preprinted_allows_empty_cai(self):
         """En preimpreso el CAI y el rango no se cargan: vienen impresos en el papel."""
@@ -178,3 +182,130 @@ class TestVoucherPrintMode(TransactionCase):
             ]
         )
         self.assertEqual(self.picking._l10n_ar_count_pages_with_products(reader), 2)
+
+
+class TestCustomPreprintedTemplate(PreprintedCommon):
+    """Plantilla QWeb propia por tipo de operación: reemplaza el comprobante estándar y
+    cambia el criterio de conteo de hojas."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.custom_view = cls.env["ir.ui.view"].create(
+            {
+                "name": "Remito preimpreso propio",
+                "type": "qweb",
+                "arch": """
+                    <t t-name="l10n_ar_stock_preprinted.remito_propio_test">
+                        <t t-call="web.html_container">
+                            <div class="page"><span t-field="o.name"/></div>
+                        </t>
+                    </t>
+                """,
+            }
+        )
+
+    def test_custom_template_replaces_standard_voucher(self):
+        """Con plantilla propia el comprobante se imprime con esa vista, no con la estándar."""
+        self.picking.company_id.country_id = self.env.ref("base.ar")
+        self.picking_type.l10n_ar_preprinted_report_view_id = self.custom_view
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            self.custom_view.key,
+        )
+
+    def test_custom_template_key_resolves_for_t_call(self):
+        """El t-call resuelve los templates por key, así que el key tiene que existir y apuntar
+        de vuelta a la vista. Odoo lo autogenera cuando la vista se crea sin key desde la
+        interfaz, que es como la va a crear el consultor."""
+        self.assertTrue(self.custom_view.key)
+        self.assertEqual(
+            self.env["ir.ui.view"]._get_template_view(self.custom_view.key),
+            self.custom_view,
+        )
+
+    def test_without_custom_template_keeps_standard_voucher(self):
+        """Sin plantilla propia no cambia nada: sigue el comprobante argentino."""
+        self.picking.company_id.country_id = self.env.ref("base.ar")
+        self.assertFalse(self.picking_type.l10n_ar_preprinted_report_view_id)
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            "l10n_ar_stock_ux.report_delivery_document",
+        )
+
+    def test_custom_template_only_applies_to_preprinted(self):
+        """En autoimpreso la plantilla propia no aplica: el campo es del flujo preimpreso."""
+        self.picking_type.l10n_ar_preprinted_report_view_id = self.custom_view
+        self.picking_type.write(
+            {
+                "l10n_ar_voucher_print_mode": "autoprinted",
+                "l10n_ar_cai_authorization_code": "12345678901234",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "00000999",
+            }
+        )
+        self.picking.company_id.country_id = self.env.ref("base.ar")
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            "l10n_ar_stock_ux.report_delivery_document",
+        )
+
+    def test_custom_template_counts_every_page(self):
+        """Con plantilla propia toda página impresa es una hoja del talonario: no se descuenta
+        ninguna aunque no traiga la marca de línea (una plantilla desde cero no la emite)."""
+        self.picking_type.l10n_ar_preprinted_report_view_id = self.custom_view
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = False
+        with patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(3), "pdf")):
+            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 3)
+
+    def test_custom_template_page_count_ignores_copies(self):
+        """El juego de copias sigue consumiendo un solo número por hoja."""
+        self.picking_type.l10n_ar_preprinted_report_view_id = self.custom_view
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = "triplicado"
+        with patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(6), "pdf")):
+            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 2)
+
+    def test_custom_template_does_not_use_line_mark(self):
+        """El conteo por marca de línea queda fuera de juego con plantilla propia: si siguiera
+        vigente, una plantilla sin marca daría una sola hoja para un remito de tres."""
+        self.picking_type.l10n_ar_preprinted_report_view_id = self.custom_view
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = False
+        with (
+            patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(3), "pdf")),
+            patch.object(type(self.picking), "_l10n_ar_count_pages_with_products", return_value=1),
+        ):
+            self.assertEqual(self.picking._l10n_ar_count_preprinted_sheets(), 3)
+
+    def test_custom_template_numbering_uses_page_count(self):
+        """Punta a punta: tres páginas impresas consumen tres números del talonario."""
+        self.picking_type.l10n_ar_preprinted_report_view_id = self.custom_view
+        report = self.env.ref("stock.action_report_delivery")
+        report.l10n_ar_copies = False
+        with patch.object(type(report), "_render_qweb_pdf", return_value=(_pdf_with_pages(3), "pdf")):
+            self.picking.l10n_ar_action_create_delivery_guide()
+        self.assertEqual(len(self.picking.l10n_ar_delivery_guide_number.split(",")), 3)
+
+    def test_extension_view_is_rejected(self):
+        """Una vista de herencia no tiene arch renderizable propio: el t-call imprimiría los
+        nodos del diff sueltos, así que no la aceptamos como plantilla."""
+        extension = self.env["ir.ui.view"].create(
+            {
+                "name": "Herencia del comprobante",
+                "type": "qweb",
+                "mode": "extension",
+                "inherit_id": self.env.ref("l10n_ar_stock_ux.report_delivery_document").id,
+                "arch": '<xpath expr="//div[@class=\'page\']" position="inside"><span/></xpath>',
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_preprinted_report_view_id = extension
+
+    def test_non_qweb_view_is_rejected(self):
+        """Tampoco una vista de formulario: el campo apunta a templates de reporte."""
+        form_view = self.env.ref("stock.view_picking_form")
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_preprinted_report_view_id = form_view

--- a/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_preprinted/views/stock_picking_type_views.xml
@@ -14,6 +14,11 @@
             <!-- Modo de impresión: solo relevante en tipos de operación con remito -->
             <field name="l10n_ar_document_type_id" position="after">
                 <field name="l10n_ar_voucher_print_mode" invisible="not l10n_ar_document_type_id"/>
+                <!-- La plantilla propia solo aplica al preimpreso: es lo que permite adaptar el
+                     contenido variable a la grilla del papel de cada imprenta. -->
+                <field name="l10n_ar_preprinted_report_view_id"
+                       invisible="not l10n_ar_document_type_id or l10n_ar_voucher_print_mode != 'preprinted'"
+                       options="{'no_create': True}"/>
             </field>
             <!-- CAI: visible y obligatorio solo en autoimpreso -->
             <field name="l10n_ar_cai_authorization_code" position="attributes">


### PR DESCRIPTION
## Qué resuelve

El comprobante de entrega estándar no siempre cae donde el papel de la imprenta lo espera: cada talonario preimpreso trae su propia grilla. Hasta ahora la única salida era un módulo a medida por cliente.

Este PR agrega un campo opcional en el tipo de operación, `l10n_ar_preprinted_report_view_id`, para apuntar a una vista QWeb propia. La arma un consultor funcional desde *Ajustes > Técnico > Vistas*, sin módulo y sin deploy. Vacío el campo, no cambia absolutamente nada.

## Cómo funciona

`_get_name_delivery_report` devuelve el **key** de la vista, no un external id. Es a propósito: el `t-call` resuelve los templates por `ir.ui.view.key` (`_get_template_domain` es `Domain('key', 'in', xmlids)`), y una vista creada desde la interfaz no tiene external id. Key en cambio siempre tiene — lo exige el constraint `_qweb_required_key` de base, y Odoo lo autogenera cuando no se lo dan.

La plantilla es un template autónomo, no una herencia del comprobante estándar. Recibe el picking en `o` y el tipo de copia en `copy_type`, y abre con `<t t-call="web.html_container">`. Un `@api.constrains` rechaza las vistas que no sean QWeb `primary`: una vista de herencia (`mode = 'extension'`) no tiene arch renderizable propio — es un diff de xpaths — así que el `t-call` imprimiría los nodos del diff sueltos en vez del remito.

## Conteo de hojas

Con plantilla propia cambia el criterio: se cuentan **todas** las páginas de una copia, en vez de solo las que traen la marca invisible de línea de producto.

La marca la inyectan herencias sobre los leaf-templates del comprobante estándar (`stock.stock_report_delivery_aggregated_move_lines` y `stock.stock_report_delivery_has_serial_move_line`). Una plantilla hecha desde cero no los llama, así que el conteo anterior encontraría cero marcas y `_l10n_ar_count_pages_with_products` devolvería `max(1, 0) = 1`: un remito de tres hojas registraría un solo número, sin ningún aviso. Es un problema fiscal, no cosmético.

Y no hace falta discriminar hojas: una plantilla dibujada para el papel de la imprenta no emite páginas que no sean del talonario, así que cada página que sale consume un número. El juego de copias (duplicado / triplicado) sigue consumiendo un solo número por hoja.

## Test plan

`--test-tags /l10n_ar_stock_preprinted` sobre una base limpia: **0 failed, 0 error(s) of 20 tests** (10 previos + 10 nuevos).

Los 10 nuevos cubren:

- la plantilla propia reemplaza al comprobante estándar, y sin plantilla no cambia nada
- el key de una vista creada sin key resuelve de vuelta a la vista vía `_get_template_view`
- la plantilla propia no aplica en autoimpreso
- el conteo devuelve todas las páginas de una copia, con y sin copias configuradas
- el conteo ignora la marca de línea (con la marca mockeada en 1, tres páginas siguen dando tres hojas)
- punta a punta: tres páginas impresas consumen tres números consecutivos del talonario
- se rechazan las vistas de herencia y las que no son QWeb

Verificado que los tests son discriminantes: neutralizando la rama nueva de `_l10n_ar_count_preprinted_sheets`, 4 de ellos fallan.

Refactor menor en el archivo de tests: el setup común pasó a una clase base `PreprintedCommon` para no re-correr los tests del modo de impresión en la clase nueva.
