### PR TITLE
[ADD] l10n_ar_stock_custom_report: own QWeb template for the delivery report

### DIFF
--- a/l10n_ar_stock_custom_report/README.rst
+++ b/l10n_ar_stock_custom_report/README.rst
@@ -1,0 +1,99 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+======================================
+Plantilla Propia del Remito Argentino
+======================================
+
+Permite que un tipo de operación imprima su remito con una **plantilla QWeb
+propia**, en lugar del comprobante estándar de ``l10n_ar_stock_ux``.
+
+El módulo no trae ninguna plantilla: trae el campo y su validación. La plantilla
+la crea un consultor funcional o el propio cliente desde *Ajustes > Técnico >
+Vistas* — sin módulo y sin deploy — o llega como data de otro módulo. Vacío el
+campo, no cambia absolutamente nada.
+
+Para qué sirve
+==============
+
+Hay dos personalizaciones del remito que aparecen en clientes reales, y el campo
+cubre las dos:
+
+* **Formato** — el talonario de cada imprenta trae su propia grilla, y el
+  comprobante estándar no siempre cae donde el papel lo espera. Se resuelve con
+  una plantilla dibujada desde cero para ese papel.
+* **Campos** — el cliente necesita datos que el comprobante no trae por defecto,
+  pero el formato nuestro le sirve. Se resuelve con una vista que hereda el
+  comprobante estándar y le agrega los campos.
+
+Qué agrega
+==========
+
+* ``stock.picking.type.l10n_ar_delivery_report_view_id`` (opcional): la vista
+  QWeb con la que se imprime el remito de ese tipo de operación. Una restricción
+  de servidor exige que sea una vista QWeb de modo ``primary`` (la vista sola no
+  cubre imports ni escrituras por ORM).
+* ``stock.picking._get_name_delivery_report`` devuelve el ``key`` de esa vista.
+  Es el key y no el external id porque el ``t-call`` resuelve los templates por
+  ``ir.ui.view.key``, y una vista creada desde la interfaz no tiene external id.
+
+Cómo se arma la plantilla
+=========================
+
+**Formato (plantilla desde cero).** Una vista QWeb con un ``<t t-name="...">``
+propio, que recibe la transferencia en la variable ``o`` y el tipo de copia en
+``copy_type``, y abre con ``<t t-call="web.html_container">`` igual que el
+comprobante estándar.
+
+Ojo: una plantilla desde cero no imprime nada que no dibuje. En autoimpreso eso
+significa que el encabezado, el número y el CAI corren por cuenta de la
+plantilla; en preimpreso es justamente lo que se busca, porque ya vienen impresos
+en el papel.
+
+**Campos (herencia del comprobante).** Una vista de modo ``primary`` con
+``inherit_id`` al comprobante estándar
+(``l10n_ar_stock_ux.report_delivery_document``) y los xpaths que agregan los
+campos. Odoo sube por la herencia y aplica el diff sobre el arch del padre, así
+que el formato, el encabezado, el número y el CAI se conservan.
+
+Lo que **no** se acepta es una vista de modo ``extension``: no tiene arch
+renderizable propio — es un diff de xpaths — así que el ``t-call`` imprimiría
+los nodos del diff sueltos en vez del remito.
+
+Configuración
+=============
+
+En *Inventario > Configuración > Tipos de operación*, para un tipo de operación
+de salida:
+
+#. Definir el *Tipo de documento* de remito.
+#. Crear la vista QWeb desde *Ajustes > Técnico > Vistas*, con uno de los dos
+   criterios de arriba.
+#. Seleccionarla en *Plantilla del Remito*.
+
+Advertencia sobre las actualizaciones de versión
+================================================
+
+Una plantilla creada en la base no está en el repositorio, así que no la cubre la
+actualización estándar de versión. Las dos formas de armarla no corren el mismo
+riesgo:
+
+* Una plantilla **desde cero** solo depende de ``web.html_container`` y de los
+  campos que lee: aguanta bien un cambio de versión.
+* Una plantilla **heredada** depende de la estructura del comprobante estándar.
+  Si un nodo se mueve, el xpath deja de aplicar y la vista se rompe. Conviene
+  revisarla en cada actualización.
+
+Credits
+=======
+
+|company| |company_logo|

--- a/l10n_ar_stock_custom_report/__init__.py
+++ b/l10n_ar_stock_custom_report/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_stock_custom_report/__manifest__.py
+++ b/l10n_ar_stock_custom_report/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Plantilla Propia del Remito Argentino",
+    "version": "19.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Permite imprimir el remito de un tipo de operación con una plantilla QWeb propia",
+    "depends": [
+        "l10n_ar_stock_ux",
+    ],
+    "data": [
+        "views/stock_picking_type_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/l10n_ar_stock_custom_report/models/__init__.py
+++ b/l10n_ar_stock_custom_report/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking_type
+from . import stock_picking

--- a/l10n_ar_stock_custom_report/models/stock_picking.py
+++ b/l10n_ar_stock_custom_report/models/stock_picking.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _get_name_delivery_report(self, report_xml_id):
+        """Si el tipo de operación tiene plantilla propia, el remito se imprime con esa.
+
+        Devolvemos el key y no el external id porque el t-call resuelve los templates por
+        ir.ui.view.key (_get_template_domain), y una vista hecha desde la interfaz no tiene
+        external id; key en cambio siempre tiene: lo exige el constraint _qweb_required_key de
+        base, y Odoo lo autogenera cuando no se lo dan. Una plantilla que llega como data de un
+        módulo también tiene key, así que las dos formas de crearla entran por acá.
+
+        No filtramos por país: el campo es de la localización argentina y solo se carga en ese
+        flujo, y si alguien lo cargó, imprimir con esa plantilla es lo que pidió."""
+        self.ensure_one()
+        custom_view = self.picking_type_id.l10n_ar_delivery_report_view_id
+        if custom_view:
+            return custom_view.key
+        return super()._get_name_delivery_report(report_xml_id)

--- a/l10n_ar_stock_custom_report/models/stock_picking_type.py
+++ b/l10n_ar_stock_custom_report/models/stock_picking_type.py
@@ -1,0 +1,52 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    l10n_ar_delivery_report_view_id = fields.Many2one(
+        "ir.ui.view",
+        string="Plantilla del Remito",
+        domain=[("type", "=", "qweb"), ("mode", "=", "primary")],
+        ondelete="restrict",
+        help="Vista QWeb propia con la que se imprime el remito de este tipo de operación, en lugar "
+        "del comprobante estándar. Vacío, se usa el comprobante estándar y nada cambia.\n"
+        "La plantilla la crea un consultor funcional o el propio cliente desde Ajustes > Técnico > "
+        "Vistas, y hay dos formas de armarla según qué se necesite personalizar:\n"
+        "* Formato: una plantilla desde cero, dibujada para la grilla del papel de la imprenta. "
+        "Recibe la transferencia en la variable 'o' (y el tipo de copia en 'copy_type') y tiene que "
+        'abrir con <t t-call="web.html_container"> igual que el comprobante estándar.\n'
+        "* Campos: una vista de modo 'primary' que herede el comprobante estándar y le agregue los "
+        "campos que falten. Conserva el formato nuestro, incluidos encabezado, número y CAI.\n"
+        "En los dos casos la vista tiene que ser QWeb y de modo 'primary'.",
+    )
+
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains("l10n_ar_delivery_report_view_id")
+    def _constrains_l10n_ar_delivery_report_view(self):
+        """La plantilla tiene que ser una vista QWeb renderizable por sí misma. El domain del
+        campo ya lo pide, pero el modo también puede setearse por import / data / ORM, donde el
+        domain no aplica.
+
+        El chequeo de 'primary' no es cosmético: una vista de modo 'extension' no tiene arch
+        renderizable propio — es un diff de xpaths — así que el t-call del comprobante imprimiría
+        los nodos del diff sueltos en vez del remito. Una vista 'primary' sí, tenga o no
+        inherit_id: cuando lo tiene, Odoo sube por la herencia y aplica el diff sobre el arch del
+        padre (ir.ui.view._get_combined_archs)."""
+        for picking_type in self.filtered("l10n_ar_delivery_report_view_id"):
+            view = picking_type.l10n_ar_delivery_report_view_id
+            if view.type != "qweb" or view.mode != "primary":
+                raise ValidationError(
+                    _(
+                        "La plantilla del remito de %(picking_type)s tiene que ser una vista QWeb"
+                        " de modo 'primary', y %(view)s es de tipo %(type)s y modo %(mode)s.\n"
+                        "Cree la plantilla desde Ajustes > Técnico > Vistas, con un <t t-name>"
+                        " propio o heredando el comprobante estándar en modo 'primary'.",
+                        picking_type=picking_type.display_name,
+                        view=view.display_name,
+                        type=view.type,
+                        mode=view.mode,
+                    )
+                )

--- a/l10n_ar_stock_custom_report/tests/__init__.py
+++ b/l10n_ar_stock_custom_report/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_custom_delivery_report

--- a/l10n_ar_stock_custom_report/tests/test_custom_delivery_report.py
+++ b/l10n_ar_stock_custom_report/tests/test_custom_delivery_report.py
@@ -1,0 +1,132 @@
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+
+class TestCustomDeliveryReport(TransactionCase):
+    """La plantilla propia del remito: cuándo reemplaza al comprobante estándar y qué vistas
+    se aceptan como plantilla."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.country_id = cls.env.ref("base.ar")
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito test",
+                "sequence_code": "TESTCUSTREM",
+                "code": "outgoing",
+                "company_id": cls.env.company.id,
+                "warehouse_id": cls.env["stock.warehouse"]
+                .search([("company_id", "=", cls.env.company.id)], limit=1)
+                .id,
+                "l10n_ar_document_type_id": cls.env.ref("l10n_ar.dc_r_r").id,
+            }
+        )
+        cls.picking = cls.env["stock.picking"].create(
+            {
+                "picking_type_id": cls.picking_type.id,
+                "location_id": cls.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": cls.env.ref("stock.stock_location_customers").id,
+            }
+        )
+        # plantilla desde cero: el caso "formato", dibujada para la grilla del papel
+        cls.custom_view = cls.env["ir.ui.view"].create(
+            {
+                "name": "Remito propio test",
+                "type": "qweb",
+                "arch": """
+                    <t t-name="l10n_ar_stock_custom_report.remito_propio_test">
+                        <t t-call="web.html_container">
+                            <div class="page"><span t-field="o.name"/></div>
+                        </t>
+                    </t>
+                """,
+            }
+        )
+
+    def test_custom_template_replaces_standard_voucher(self):
+        """Con plantilla propia el remito se imprime con esa vista, no con la estándar."""
+        self.picking_type.l10n_ar_delivery_report_view_id = self.custom_view
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            self.custom_view.key,
+        )
+
+    def test_without_custom_template_keeps_standard_voucher(self):
+        """Sin plantilla propia no cambia nada: sigue el comprobante argentino."""
+        self.assertFalse(self.picking_type.l10n_ar_delivery_report_view_id)
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            "l10n_ar_stock_ux.report_delivery_document",
+        )
+
+    def test_custom_template_does_not_depend_on_the_country(self):
+        """El hook no filtra por país: si el campo está cargado, se imprime con esa plantilla.
+        Es lo que distingue este campo del flujo preimpreso, que sí es solo argentino."""
+        self.env.company.country_id = self.env.ref("base.uy")
+        self.picking_type.l10n_ar_delivery_report_view_id = self.custom_view
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            self.custom_view.key,
+        )
+
+    def test_custom_template_key_resolves_for_t_call(self):
+        """El t-call resuelve los templates por key, así que el key tiene que existir y apuntar
+        de vuelta a la vista. Odoo lo autogenera cuando la vista se crea sin key desde la
+        interfaz, que es como la va a crear el consultor o el cliente."""
+        self.assertTrue(self.custom_view.key)
+        self.assertEqual(
+            self.env["ir.ui.view"]._get_template_view(self.custom_view.key),
+            self.custom_view,
+        )
+
+    def test_inheriting_primary_view_is_accepted(self):
+        """El caso "campos": una vista primary que hereda el comprobante estándar se acepta y
+        renderiza, porque Odoo aplica su diff sobre el arch del padre. Es el mismo patrón con el
+        que el producto arma su propio comprobante argentino sobre el de stock."""
+        inheriting_view = self.env["ir.ui.view"].create(
+            {
+                "name": "Remito con campos propios",
+                "type": "qweb",
+                "mode": "primary",
+                "inherit_id": self.env.ref("l10n_ar_stock_ux.report_delivery_document").id,
+                "arch": '<xpath expr="//div[@class=\'page\']" position="inside"><span/></xpath>',
+            }
+        )
+        self.picking_type.l10n_ar_delivery_report_view_id = inheriting_view
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            inheriting_view.key,
+        )
+
+    def test_extension_view_is_rejected(self):
+        """Una vista de modo 'extension' no tiene arch renderizable propio: el t-call imprimiría
+        los nodos del diff sueltos, así que no la aceptamos como plantilla."""
+        extension_view = self.env["ir.ui.view"].create(
+            {
+                "name": "Herencia del comprobante",
+                "type": "qweb",
+                "mode": "extension",
+                "inherit_id": self.env.ref("l10n_ar_stock_ux.report_delivery_document").id,
+                "arch": '<xpath expr="//div[@class=\'page\']" position="inside"><span/></xpath>',
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_delivery_report_view_id = extension_view
+
+    def test_non_qweb_view_is_rejected(self):
+        """Tampoco una vista de formulario: el campo apunta a templates de reporte."""
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_delivery_report_view_id = self.env.ref("stock.view_picking_form")
+
+    @mute_logger("odoo.sql_db")
+    def test_view_in_use_cannot_be_deleted(self):
+        """Borrar la plantilla dejaría el tipo de operación imprimiendo un template inexistente,
+        así que el campo es ondelete restrict."""
+        self.picking_type.l10n_ar_delivery_report_view_id = self.custom_view
+        self.env.flush_all()
+        with self.assertRaises(IntegrityError):
+            with self.cr.savepoint():
+                self.custom_view.unlink()

--- a/l10n_ar_stock_custom_report/views/stock_picking_type_views.xml
+++ b/l10n_ar_stock_custom_report/views/stock_picking_type_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- La plantilla propia aplica a los dos modos de impresión del remito: en preimpreso
+         reemplaza el formato para que caiga en la grilla del papel de la imprenta, y en
+         autoimpreso sirve para agregar campos que el comprobante estándar no trae. Por eso
+         la visibilidad depende solo de que el tipo de operación tenga remito. -->
+    <record id="view_picking_type_form_custom_report" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.custom.report</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="l10n_ar_stock.view_picking_type_form_inherit_l10n_ar_stock"/>
+        <field name="arch" type="xml">
+            <field name="l10n_ar_document_type_id" position="after">
+                <field name="l10n_ar_delivery_report_view_id"
+                       invisible="not l10n_ar_document_type_id"
+                       options="{'no_create': True}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Qué resuelve

El remito de un cliente no siempre se imprime con nuestro formato: el talonario
de cada imprenta trae su propia grilla, y hay clientes que además necesitan
campos que el comprobante estándar no trae. Hasta ahora la única salida era un
módulo a medida por cliente, o un reporte aeroo sustituido.

Este módulo agrega un campo opcional en el tipo de operación,
`l10n_ar_delivery_report_view_id`, para apuntar a una vista QWeb propia. La arma
un consultor funcional o el propio cliente desde *Ajustes > Técnico > Vistas*,
sin módulo y sin deploy. Vacío el campo, no cambia absolutamente nada.

El módulo **no trae ninguna plantilla**: trae el campo y su validación.

## Las dos personalizaciones, con un solo campo

* **Formato** — plantilla dibujada desde cero para el papel de la imprenta.
  Recibe el picking en `o` y el tipo de copia en `copy_type`, y abre con
  `<t t-call="web.html_container">`. Es el caso del remito preimpreso.
* **Campos** — vista de modo `primary` que hereda
  `l10n_ar_stock_ux.report_delivery_document` y le agrega los campos que falten.
  Conserva formato, encabezado, número y CAI, así que sirve también en
  autoimpreso.

Por eso el hook no mira el modo de impresión ni el país: si el campo está
cargado, se imprime con esa plantilla.

## Cómo funciona

`_get_name_delivery_report` devuelve el **key** de la vista, no un external id.
Es a propósito: el `t-call` resuelve los templates por `ir.ui.view.key`
(`_get_template_domain` es `Domain('key', 'in', xmlids)`), y una vista creada
desde la interfaz no tiene external id. Key en cambio siempre tiene — lo exige el
constraint `_qweb_required_key` de base, y Odoo lo autogenera. Una plantilla que
llega como data de un módulo también tiene key, así que los dos orígenes entran
por el mismo hook.

Un `@api.constrains` acepta solo vistas QWeb de modo `primary`. Una vista
`extension` no tiene arch renderizable propio — es un diff de xpaths — así que el
`t-call` imprimiría los nodos del diff sueltos en vez del remito. Una `primary`
**con** `inherit_id` sí se acepta, y es deliberado: Odoo sube por la herencia y
aplica el diff sobre el arch del padre (`_get_combined_archs`). Es el mismo
patrón con el que el producto arma su comprobante argentino sobre el de stock.

## Orden de merge: después del #321

Este PR asume que #321 ya está mezclado, porque ese saca de
`l10n_ar_stock_preprinted` un override redundante de `_get_name_delivery_report`
(el de `l10n_ar_stock_ux` ya devuelve el comprobante argentino para toda compañía
AR). Ese override devuelve temprano y, al cargarse después de este módulo, taparía
el hook en los tipos preimpresos.

No hay conflicto de archivos: este módulo es nuevo y no toca
`l10n_ar_stock_preprinted`.

## Relación con el #335

Reemplaza el mecanismo que el #335 metía dentro de `l10n_ar_stock_preprinted`, que
quedaba atado al modo preimpreso y por eso no cubría el caso "agregar campos" en
autoimpreso. Con este módulo, el #335 se cierra sin mergear.

También queda afuera la rama de conteo de hojas del #335: el #321 unifica el
criterio en "todas las páginas de una copia" para todos los preimpresos, así que
no hay nada que bifurcar según la plantilla.

## Test plan

8 tests nuevos en `tests/test_custom_delivery_report.py`:

- la plantilla propia reemplaza al comprobante estándar, y sin plantilla no cambia nada
- el campo no depende del país
- el key de una vista creada sin key resuelve de vuelta a la vista vía `_get_template_view`
- se acepta una vista `primary` que hereda el comprobante (el caso "campos")
- se rechazan las vistas `extension` y las que no son QWeb
- la vista en uso no se puede borrar (`ondelete="restrict"`)

`pre-commit run --files` pasa sobre los 9 archivos (ruff, ruff-format, pylint-odoo,
check-xml, rstcheck). **Los tests de Odoo no los corrí en local** — no levanté base
para esto, los corre el CI.
