### PR TITLE
[19.0][FIX] l10n_ar_stock_ux: respuesta exitosa del COT interpretada como error

### DIFF
--- a/l10n_ar_stock_ux/__manifest__.py
+++ b/l10n_ar_stock_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Remitos, COT y demas ajustes de stock para Argentina",
-    "version": "19.0.1.11.0",
+    "version": "19.0.1.11.1",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_stock_ux/models/stock_picking.py
+++ b/l10n_ar_stock_ux/models/stock_picking.py
@@ -425,7 +425,12 @@ class StockPicking(models.Model):
 
     def _parse_arba_response(self, response_content):
         root = ET.fromstring(response_content)
-        process = root.find(".//procesado") and root.find(".//procesado").text == "SI"
+        # Un Element sin hijos evalua como False en ElementTree, asi que
+        # `root.find(...) and ...` trataba las respuestas EXITOSAS (procesado=SI)
+        # como fallidas: se descartaba el COT ya otorgado y el reintento daba
+        # error 17 "El remito ya fue procesado con anterioridad".
+        procesado = root.find(".//procesado")
+        process = procesado is not None and procesado.text == "SI"
         if process:
             try:
                 return {


### PR DESCRIPTION
## Bug

En `_parse_arba_response`:

```python
process = root.find(".//procesado") and root.find(".//procesado").text == "SI"
```

Un `Element` de ElementTree **sin hijos evalúa como `False`** (Python emite
`DeprecationWarning: Testing an element's truth value will raise an exception in future versions`).
`<procesado>SI</procesado>` no tiene hijos, así que el `and` corta en falso y `process`
queda `False` **también cuando la presentación fue exitosa**.

## Consecuencia

- La respuesta exitosa de ARBA cae en la rama de error, que busca `<errores>` — no hay
  ninguno — y levanta un `UserError` con la lista vacía: *"Error al presentar remito:"*
  sin ningún detalle.
- El COT ya otorgado por ARBA se descarta sin guardarse en el picking.
- Todo reintento devuelve `17 - El remito ya fue procesado con anterioridad`, porque el
  primer intento sí registró el remito.

Reproducción mínima:

```python
import xml.etree.ElementTree as ET
r = ET.fromstring('<a><procesado>SI</procesado></a>')
bool(r.find('.//procesado'))   # False (!)
```

## Fix

Comparar contra `None`, como pide la propia deprecación. Verificado en producción
(Odoo 19 / odoo.sh): con el fix, la presentación guarda COT, número único y comprobante,
y adjunta el TXT al chatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)