### PR TITLE
[ADD] l10n_ar_preprinted_template: own QWeb template for the preprinted delivery slip

### DIFF
--- a/l10n_ar_preprinted_template/README.rst
+++ b/l10n_ar_preprinted_template/README.rst
@@ -1,0 +1,131 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=======================================
+Plantilla Propia del Remito Preimpreso
+=======================================
+
+Permite que un tipo de operación con remito **preimpreso** lo imprima con una
+**plantilla QWeb propia**, en lugar del comprobante estándar de
+``l10n_ar_stock_ux``.
+
+El módulo no trae ninguna plantilla: trae el campo y su validación. La plantilla
+la crea un consultor funcional o el propio cliente desde *Ajustes > Técnico >
+Vistas* — sin módulo y sin deploy — o llega como data de otro módulo. Vacío el
+campo, no cambia absolutamente nada.
+
+Reemplaza el camino anterior, que era un reporte aeroo sustituyendo el nuestro
+con ``report_substitute``: un módulo descartado en 19, que además cobraba líneas
+de personalización. Este módulo es producto soportado y la plantilla creada en
+base no cuenta líneas.
+
+El módulo **no** es auto-instalable: se instala solo en las bases donde el
+cliente tiene la perso. El estándar sigue siendo nuestro remito.
+
+Para qué sirve
+==============
+
+Hay dos personalizaciones del remito que aparecen en clientes reales, y el campo
+cubre las dos:
+
+* **Formato** — el talonario de cada imprenta trae su propia grilla, y el
+  comprobante estándar no siempre cae donde el papel lo espera. Se resuelve con
+  una plantilla dibujada desde cero para ese papel.
+* **Campos** — el cliente necesita datos que el comprobante no trae por defecto,
+  pero el formato nuestro le sirve. Se resuelve con una vista que hereda el
+  comprobante estándar y le agrega los campos.
+
+Qué agrega
+==========
+
+* ``stock.picking.type.l10n_ar_delivery_report_view_id`` (opcional): la vista
+  QWeb con la que se imprime el remito de ese tipo de operación. Una restricción
+  de servidor exige que sea una vista QWeb de modo ``primary`` (la vista sola no
+  cubre imports ni escrituras por ORM).
+* ``stock.picking._get_name_delivery_report`` devuelve el ``key`` de esa vista.
+  Es el key y no el external id porque el ``t-call`` resuelve los templates por
+  ``ir.ui.view.key``, y una vista creada desde la interfaz no tiene external id.
+
+Alcance: solo preimpreso
+========================
+
+La plantilla propia se aplica **solo** cuando el *Modo de Impresión del Remito*
+del tipo de operación es *Preimpreso*, y el campo se muestra solo en ese modo.
+
+Es una decisión deliberada, no un límite del mecanismo. El hook y la validación
+sirven igual en autoimpreso: una vista ``primary`` que hereda el comprobante
+estándar conserva encabezado, número y CAI, así que el caso "agregar campos"
+funcionaría tal cual. No se abre porque hoy no hay demanda de perso en
+autoimpreso, y porque una plantilla dibujada desde cero en autoimpreso saldría
+sin número y sin CAI sobre papel en blanco — ahí sí haría falta un aviso al
+guardar, que con el caso cerrado no hace falta.
+
+Dos consecuencias prácticas:
+
+* El cliente que pasa de preimpreso a remito digital no tiene que borrar la
+  plantilla: deja de verla y deja de aplicarse.
+* El día que aparezca demanda de perso en autoimpreso, se saca la condición del
+  hook, se abre la visibilidad del campo y se define ahí el aviso al guardar.
+
+Cómo se arma la plantilla
+=========================
+
+**Formato (plantilla desde cero).** Una vista QWeb con un ``<t t-name="...">``
+propio, que recibe la transferencia en la variable ``o`` y el tipo de copia en
+``copy_type``, y abre con ``<t t-call="web.html_container">`` igual que el
+comprobante estándar.
+
+Ojo: una plantilla desde cero no imprime nada que no dibuje. En preimpreso es
+justamente lo que se busca, porque el encabezado, el número y el CAI ya vienen
+impresos en el papel de la imprenta.
+
+**Campos (herencia del comprobante).** Una vista de modo ``primary`` con
+``inherit_id`` al comprobante estándar
+(``l10n_ar_stock_ux.report_delivery_document``) y los xpaths que agregan los
+campos. Odoo sube por la herencia y aplica el diff sobre el arch del padre, así
+que se conserva el formato nuestro, con el encabezado y el pie que el preimpreso
+deja en blanco.
+
+Lo que **no** se acepta es una vista de modo ``extension``: no tiene arch
+renderizable propio — es un diff de xpaths — así que el ``t-call`` imprimiría
+los nodos del diff sueltos en vez del remito.
+
+Configuración
+=============
+
+En *Inventario > Configuración > Tipos de operación*, para un tipo de operación
+de salida:
+
+#. Definir el *Tipo de documento* de remito.
+#. Poner el *Modo de Impresión del Remito* en *Preimpreso*
+   (``l10n_ar_stock_preprinted``).
+#. Crear la vista QWeb desde *Ajustes > Técnico > Vistas*, con uno de los dos
+   criterios de arriba.
+#. Seleccionarla en *Plantilla del Remito*.
+
+Advertencia sobre las actualizaciones de versión
+================================================
+
+Una plantilla creada en la base no está en el repositorio, así que no la cubre la
+actualización estándar de versión. Las dos formas de armarla no corren el mismo
+riesgo:
+
+* Una plantilla **desde cero** solo depende de ``web.html_container`` y de los
+  campos que lee: aguanta bien un cambio de versión.
+* Una plantilla **heredada** depende de la estructura del comprobante estándar.
+  Si un nodo se mueve, el xpath deja de aplicar y la vista se rompe. Conviene
+  revisarla en cada actualización.
+
+Credits
+=======
+
+|company| |company_logo|

--- a/l10n_ar_preprinted_template/__init__.py
+++ b/l10n_ar_preprinted_template/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_preprinted_template/__manifest__.py
+++ b/l10n_ar_preprinted_template/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    "name": "Plantilla Propia del Remito Preimpreso",
+    "version": "19.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Permite imprimir el remito preimpreso de un tipo de operación con una plantilla QWeb propia",
+    "depends": [
+        "l10n_ar_stock_preprinted",
+    ],
+    "data": [
+        "views/stock_picking_type_views.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/l10n_ar_preprinted_template/models/__init__.py
+++ b/l10n_ar_preprinted_template/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking_type
+from . import stock_picking

--- a/l10n_ar_preprinted_template/models/stock_picking.py
+++ b/l10n_ar_preprinted_template/models/stock_picking.py
@@ -1,0 +1,30 @@
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _get_name_delivery_report(self, report_xml_id):
+        """Si el tipo de operación tiene plantilla propia, el remito preimpreso se imprime con esa.
+
+        Devolvemos el key y no el external id porque el t-call resuelve los templates por
+        ir.ui.view.key (_get_template_domain), y una vista hecha desde la interfaz no tiene
+        external id; key en cambio siempre tiene: lo exige el constraint _qweb_required_key de
+        base, y Odoo lo autogenera cuando no se lo dan. Una plantilla que llega como data de un
+        módulo también tiene key, así que las dos formas de crearla entran por acá.
+
+        La plantilla se aplica SOLO en preimpreso, y es una decisión deliberada, no un límite
+        del mecanismo: el hook y el constraint sirven igual en autoimpreso (una vista primary
+        que hereda el comprobante estándar conserva encabezado, número y CAI, así que el caso
+        "agregar campos" funcionaría tal cual). No lo abrimos porque hoy no hay demanda de
+        perso en autoimpreso: el día que aparezca, se saca esta condición y se define ahí el
+        aviso al guardar que hoy no hace falta — una plantilla dibujada desde cero en
+        autoimpreso sale sin número y sin CAI, y el papel está en blanco. Mientras siga
+        cerrado, el cliente que pasa de preimpreso a remito digital deja de usar la plantilla
+        sin tener que borrarla: se ignora sola.
+        """
+        self.ensure_one()
+        custom_view = self.picking_type_id.l10n_ar_delivery_report_view_id
+        if custom_view and self.l10n_ar_voucher_print_mode == "preprinted":
+            return custom_view.key
+        return super()._get_name_delivery_report(report_xml_id)

--- a/l10n_ar_preprinted_template/models/stock_picking_type.py
+++ b/l10n_ar_preprinted_template/models/stock_picking_type.py
@@ -1,0 +1,55 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    l10n_ar_delivery_report_view_id = fields.Many2one(
+        "ir.ui.view",
+        string="Plantilla del Remito",
+        domain=[("type", "=", "qweb"), ("mode", "=", "primary")],
+        ondelete="restrict",
+        help="Vista QWeb propia con la que se imprime el remito preimpreso de este tipo de "
+        "operación, en lugar del comprobante estándar. Vacío, se usa el comprobante estándar y "
+        "nada cambia.\n"
+        "La plantilla la crea un consultor funcional o el propio cliente desde Ajustes > Técnico > "
+        "Vistas, y hay dos formas de armarla según qué se necesite personalizar:\n"
+        "* Formato: una plantilla desde cero, dibujada para la grilla del papel de la imprenta. "
+        "Recibe la transferencia en la variable 'o' (y el tipo de copia en 'copy_type') y tiene que "
+        'abrir con <t t-call="web.html_container"> igual que el comprobante estándar.\n'
+        "* Campos: una vista de modo 'primary' que herede el comprobante estándar y le agregue los "
+        "campos que falten. Conserva el formato nuestro, incluida la fecha del encabezado.\n"
+        "En los dos casos la vista tiene que ser QWeb y de modo 'primary'.\n"
+        "Solo aplica cuando el Modo de Impresión del Remito es Preimpreso: en autoimpreso el "
+        "remito se imprime siempre con el comprobante estándar.",
+    )
+
+    # === CONSTRAINT METHODS === #
+
+    @api.constrains("l10n_ar_delivery_report_view_id")
+    def _constrains_l10n_ar_delivery_report_view(self):
+        """La plantilla tiene que ser una vista QWeb renderizable por sí misma. El domain del
+        campo ya lo pide, pero el modo también puede setearse por import / data / ORM, donde el
+        domain no aplica.
+
+        El chequeo de 'primary' no es cosmético: una vista de modo 'extension' no tiene arch
+        renderizable propio — es un diff de xpaths — así que el t-call del comprobante imprimiría
+        los nodos del diff sueltos en vez del remito. Una vista 'primary' sí, tenga o no
+        inherit_id: cuando lo tiene, Odoo sube por la herencia y aplica el diff sobre el arch del
+        padre (ir.ui.view._get_combined_archs)."""
+        for picking_type in self.filtered("l10n_ar_delivery_report_view_id"):
+            view = picking_type.l10n_ar_delivery_report_view_id
+            if view.type != "qweb" or view.mode != "primary":
+                raise ValidationError(
+                    _(
+                        "La plantilla del remito de %(picking_type)s tiene que ser una vista QWeb"
+                        " de modo 'primary', y %(view)s es de tipo %(type)s y modo %(mode)s.\n"
+                        "Cree la plantilla desde Ajustes > Técnico > Vistas, con un <t t-name>"
+                        " propio o heredando el comprobante estándar en modo 'primary'.",
+                        picking_type=picking_type.display_name,
+                        view=view.display_name,
+                        type=view.type,
+                        mode=view.mode,
+                    )
+                )

--- a/l10n_ar_preprinted_template/tests/__init__.py
+++ b/l10n_ar_preprinted_template/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_preprinted_template

--- a/l10n_ar_preprinted_template/tests/test_preprinted_template.py
+++ b/l10n_ar_preprinted_template/tests/test_preprinted_template.py
@@ -1,0 +1,161 @@
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
+from psycopg2 import IntegrityError
+
+
+class TestPreprintedTemplate(TransactionCase):
+    """La plantilla propia del remito: cuándo reemplaza al comprobante estándar, cuándo no, y
+    qué vistas se aceptan como plantilla."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.company.country_id = cls.env.ref("base.ar")
+        cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
+        cls.picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Remito preimpreso test",
+                "sequence_code": "TESTPRETEM",
+                "code": "outgoing",
+                "company_id": cls.env.company.id,
+                "warehouse_id": cls.warehouse.id,
+                "l10n_ar_document_type_id": cls.env.ref("l10n_ar.dc_r_r").id,
+                "l10n_ar_voucher_print_mode": "preprinted",
+            }
+        )
+        cls.picking = cls.env["stock.picking"].create(
+            {
+                "picking_type_id": cls.picking_type.id,
+                "location_id": cls.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": cls.env.ref("stock.stock_location_customers").id,
+            }
+        )
+        # plantilla desde cero: el caso "formato", dibujada para la grilla del papel
+        cls.custom_view = cls.env["ir.ui.view"].create(
+            {
+                "name": "Remito propio test",
+                "type": "qweb",
+                "arch": """
+                    <t t-name="l10n_ar_preprinted_template.remito_propio_test">
+                        <t t-call="web.html_container">
+                            <div class="page"><span t-field="o.name"/></div>
+                        </t>
+                    </t>
+                """,
+            }
+        )
+
+    def test_custom_template_replaces_standard_voucher(self):
+        """Con plantilla propia el remito preimpreso se imprime con esa vista.
+
+        El assert vale también como garantía de orden de carga: ``l10n_ar_stock_preprinted``
+        tiene (hasta el #321) su propio override de este método que devuelve el comprobante
+        argentino y corta la cadena. Como este módulo depende de él, se carga después y su
+        override queda primero en el MRO, así que la plantilla propia gana sin depender de en
+        qué orden se mezclen los PRs."""
+        self.picking_type.l10n_ar_delivery_report_view_id = self.custom_view
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            self.custom_view.key,
+        )
+
+    def test_without_custom_template_keeps_standard_voucher(self):
+        """Sin plantilla propia no cambia nada: sigue el comprobante argentino."""
+        self.assertFalse(self.picking_type.l10n_ar_delivery_report_view_id)
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            "l10n_ar_stock_ux.report_delivery_document",
+        )
+
+    def test_custom_template_is_ignored_in_autoprinted(self):
+        """En autoimpreso la plantilla propia NO aplica, y es deliberado, no una limitación del
+        mecanismo: el hook y el constraint funcionan igual, pero hoy no hay demanda de perso en
+        autoimpreso y una plantilla desde cero saldría sin número y sin CAI. Por eso el cliente
+        que pasa de preimpreso a remito digital no tiene que borrar nada: deja de aplicarse."""
+        autoprinted_type = self.env["stock.picking.type"].create(
+            {
+                "name": "Remito autoimpreso test",
+                "sequence_code": "TESTAUTTEM",
+                "code": "outgoing",
+                "company_id": self.env.company.id,
+                "warehouse_id": self.warehouse.id,
+                "l10n_ar_document_type_id": self.env.ref("l10n_ar.dc_r_r").id,
+                "l10n_ar_voucher_print_mode": "autoprinted",
+                "l10n_ar_cai_authorization_code": "12345678901234",
+                "l10n_ar_cai_expiration_date": "2030-12-31",
+                "l10n_ar_sequence_number_start": "00000001",
+                "l10n_ar_sequence_number_end": "00001000",
+                "l10n_ar_delivery_report_view_id": self.custom_view.id,
+            }
+        )
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": autoprinted_type.id,
+                "location_id": self.env.ref("stock.stock_location_stock").id,
+                "location_dest_id": self.env.ref("stock.stock_location_customers").id,
+            }
+        )
+        self.assertEqual(
+            picking._get_name_delivery_report("stock.report_delivery_document"),
+            "l10n_ar_stock_ux.report_delivery_document",
+        )
+
+    def test_custom_template_key_resolves_for_t_call(self):
+        """El t-call resuelve los templates por key, así que el key tiene que existir y apuntar
+        de vuelta a la vista. Odoo lo autogenera cuando la vista se crea sin key desde la
+        interfaz, que es como la va a crear el consultor o el cliente."""
+        self.assertTrue(self.custom_view.key)
+        self.assertEqual(
+            self.env["ir.ui.view"]._get_template_view(self.custom_view.key),
+            self.custom_view,
+        )
+
+    def test_inheriting_primary_view_is_accepted(self):
+        """El caso "campos": una vista primary que hereda el comprobante estándar se acepta y
+        renderiza, porque Odoo aplica su diff sobre el arch del padre. Es el mismo patrón con el
+        que el producto arma su propio comprobante argentino sobre el de stock."""
+        inheriting_view = self.env["ir.ui.view"].create(
+            {
+                "name": "Remito con campos propios",
+                "type": "qweb",
+                "mode": "primary",
+                "inherit_id": self.env.ref("l10n_ar_stock_ux.report_delivery_document").id,
+                "arch": """<xpath expr="//div[hasclass('page')]" position="inside"><span/></xpath>""",
+            }
+        )
+        self.picking_type.l10n_ar_delivery_report_view_id = inheriting_view
+        self.assertEqual(
+            self.picking._get_name_delivery_report("stock.report_delivery_document"),
+            inheriting_view.key,
+        )
+
+    def test_extension_view_is_rejected(self):
+        """Una vista de modo 'extension' no tiene arch renderizable propio: el t-call imprimiría
+        los nodos del diff sueltos, así que no la aceptamos como plantilla."""
+        extension_view = self.env["ir.ui.view"].create(
+            {
+                "name": "Herencia del comprobante",
+                "type": "qweb",
+                "mode": "extension",
+                "inherit_id": self.env.ref("l10n_ar_stock_ux.report_delivery_document").id,
+                "arch": """<xpath expr="//div[hasclass('page')]" position="inside"><span/></xpath>""",
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_delivery_report_view_id = extension_view
+
+    def test_non_qweb_view_is_rejected(self):
+        """Tampoco una vista de formulario: el campo apunta a templates de reporte."""
+        with self.assertRaises(ValidationError):
+            self.picking_type.l10n_ar_delivery_report_view_id = self.env.ref("stock.view_picking_form")
+
+    @mute_logger("odoo.sql_db")
+    def test_view_in_use_cannot_be_deleted(self):
+        """Borrar la plantilla dejaría el tipo de operación imprimiendo un template inexistente,
+        así que el campo es ondelete restrict."""
+        self.picking_type.l10n_ar_delivery_report_view_id = self.custom_view
+        self.env.flush_all()
+        with self.assertRaises(IntegrityError):
+            with self.cr.savepoint():
+                self.custom_view.unlink()

--- a/l10n_ar_preprinted_template/views/stock_picking_type_views.xml
+++ b/l10n_ar_preprinted_template/views/stock_picking_type_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!-- La plantilla propia aplica solo al remito preimpreso, así que el campo se muestra solo
+         en ese modo: en autoimpreso el remito se imprime siempre con el comprobante estándar y
+         cargar una plantilla no haría nada. Es la misma razón por la que el cliente que pasa de
+         preimpreso a remito digital no tiene que borrar la plantilla vieja: deja de verla y deja
+         de aplicarse. El día que se abra la perso en autoimpreso, se saca esta condición. -->
+    <record id="view_picking_type_form_preprinted_template" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.preprinted.template</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="l10n_ar_stock_preprinted.view_picking_type_form_preprinted"/>
+        <field name="arch" type="xml">
+            <field name="l10n_ar_voucher_print_mode" position="after">
+                <field name="l10n_ar_delivery_report_view_id"
+                       invisible="not l10n_ar_document_type_id or l10n_ar_voucher_print_mode != 'preprinted'"
+                       options="{'no_create': True}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Qué resuelve

El remito de un cliente no siempre se imprime con nuestro formato: el talonario de
cada imprenta trae su propia grilla, y hay clientes que además necesitan campos que
el comprobante estándar no trae. Hasta ahora la única salida era un reporte aeroo
sustituyendo el nuestro con `report_substitute`, módulo descartado en 19.0.

Este módulo agrega un campo opcional en el tipo de operación,
`l10n_ar_delivery_report_view_id`, para apuntar a una vista QWeb propia. La arma un
consultor funcional o el propio cliente desde *Ajustes > Técnico > Vistas*, sin
módulo y sin deploy. Vacío el campo, no cambia absolutamente nada.

El módulo **no trae ninguna plantilla**: trae el campo, el hook y la validación. No
es auto-instalable — se instala solo donde el cliente tiene la perso, así que
nuestro remito sigue siendo el estándar.

## Alcance: solo preimpreso

La plantilla propia se aplica **solo** cuando el modo de impresión del remito es
`preprinted`, y el campo se muestra solo en ese modo.

Es una decisión deliberada, no un límite del mecanismo: el hook y el constraint
funcionan igual en autoimpreso, y una vista `primary` que hereda el comprobante
conserva encabezado, número y CAI, así que el caso "agregar campos" andaría tal
cual. Queda cerrado porque hoy no hay demanda de perso en autoimpreso, y porque una
plantilla dibujada desde cero ahí saldría sin número y sin CAI sobre papel en
blanco — recién entonces hace falta un aviso al guardar.

Dos consecuencias: el cliente que pasa de preimpreso a remito digital no tiene que
borrar la plantilla (deja de aplicarse sola), y abrir autoimpreso más adelante es
sacar la condición del hook, abrir la visibilidad del campo y definir ahí el aviso.

## Cómo funciona

`_get_name_delivery_report` devuelve el **key** de la vista, no un external id. Es a
propósito: el `t-call` resuelve los templates por `ir.ui.view.key`
(`_get_template_domain`), y una vista creada desde la interfaz no tiene external id.
Key en cambio siempre tiene — lo exige el constraint `_qweb_required_key` de base, y
Odoo lo autogenera. Una plantilla que llega como data de un módulo también tiene
key, así que los dos orígenes entran por el mismo hook.

Un `@api.constrains` acepta solo vistas QWeb de modo `primary`. Una vista
`extension` no tiene arch renderizable propio — es un diff de xpaths — así que el
`t-call` imprimiría los nodos del diff sueltos en vez del remito. Una `primary`
**con** `inherit_id` sí se acepta, y es deliberado: Odoo sube por la herencia y
aplica el diff sobre el arch del padre (`_get_combined_archs`). Es el mismo patrón
con el que el producto arma su comprobante argentino sobre el de stock.

## Dependencia y orden de merge

Depende de `l10n_ar_stock_preprinted`, que es lo que hace posible el gate (de ahí
sale `l10n_ar_voucher_print_mode`). De paso resuelve el orden de carga: nuestro
override se registra último, así que queda primero en el MRO y la plantilla propia
gana sobre el `_get_name_delivery_report` de ese módulo (el que #321 saca por
redundante), sin importar en qué orden se mezclen los PRs. El test
`test_custom_template_replaces_standard_voucher` lo cubre.

Igual conviene que #321 entre antes, por lo que ya trae: criterio único de conteo de
hojas y borrado de ese override.

## Relación con #336 y #335

Toma como base el [#336](https://github.com/ingadhoc/argentina-sale/pull/336) de
@ica-adhoc — mismo mecanismo, con el gate a preimpreso, el módulo renombrado a
`l10n_ar_preprinted_template` y la dependencia movida a `l10n_ar_stock_preprinted`.
Con este PR, #336 y #335 se cierran sin mezclar.

## Test plan

8 tests en `tests/test_preprinted_template.py`:

- la plantilla propia reemplaza al comprobante estándar en preimpreso, y sin
  plantilla no cambia nada
- en autoimpreso la misma plantilla NO aplica (el gate deliberado)
- el key de una vista creada sin key resuelve de vuelta a la vista vía
  `_get_template_view`
- se acepta una vista `primary` que hereda el comprobante (el caso "campos")
- se rechazan las vistas `extension` y las que no son QWeb
- la vista en uso no se puede borrar (`ondelete="restrict"`)

Corridos en local sobre base 19.0 limpia: **8/8 verdes**. `pre-commit` pasa.

Además, verificado a mano el render end-to-end (no solo el hook): con el tipo de
operación en preimpreso y una vista creada en base, el `t-call` resuelve su key
autogenerado y el PDF sale con la plantilla propia; pasando el mismo tipo a
autoimpreso, vuelve el comprobante estándar.

## Fuera de alcance

Renderizando el comprobante estándar de una transferencia **sin partner y sin
moves** (un picking vacío), `l10n_ar_stock_ux` falla con
`'stock.move' object has no attribute 'commercial_partner_id'`: en
`report_deliveryslip.xml` el fallback `o.partner_id or (o.move_ids and
o.move_ids[0].partner_id)` deja `partner` como un `stock.move` vacío. Es
preexistente y no lo toca este PR.
